### PR TITLE
RFC: Use less subprocess call

### DIFF
--- a/vmms/distDocker.py
+++ b/vmms/distDocker.py
@@ -33,7 +33,10 @@ def timeout(command, time_out=1):
 
     # Determine why the while loop terminated
     if p.poll() is None:
-        subprocess.call(["/bin/kill", "-9", str(p.pid)])
+        try:
+            os.kill(p.pid, 9)
+        except OSError:
+            pass
         returncode = -1
     else:
         returncode = p.poll()

--- a/vmms/ec2SSH.py
+++ b/vmms/ec2SSH.py
@@ -9,6 +9,7 @@
 #   ec2CallError - raised by ec2Call() function
 #
 import subprocess
+import os
 import re
 import time
 import logging
@@ -38,7 +39,10 @@ def timeout(command, time_out=1):
 
     # Determine why the while loop terminated
     if p.poll() is None:
-        subprocess.call(["/bin/kill", "-9", str(p.pid)])
+        try:
+            os.kill(p.pid, 9)
+        except OSError:
+            pass
         returncode = -1
     else:
         returncode = p.poll()

--- a/vmms/localDocker.py
+++ b/vmms/localDocker.py
@@ -25,7 +25,10 @@ def timeout(command, time_out=1):
 
     # Determine why the while loop terminated
     if p.poll() is None:
-        subprocess.call(["/bin/kill", "-9", str(p.pid)])
+        try:
+            os.kill(p.pid, 9)
+        except OSError:
+            pass
         returncode = -1
     else:
         returncode = p.poll()

--- a/vmms/tashiSSH.py
+++ b/vmms/tashiSSH.py
@@ -10,6 +10,7 @@
 #
 import random
 import subprocess
+import os
 import re
 import time
 import logging
@@ -41,7 +42,10 @@ def timeout(command, time_out=1):
 
     # Determine why the while loop terminated
     if p.poll() is None:
-        subprocess.call(["/bin/kill", "-9", str(p.pid)])
+        try:
+            os.kill(p.pid, 9)
+        except OSError:
+            pass
         returncode = -1
     else:
         returncode = p.poll()


### PR DESCRIPTION
I found some suspect uses of subprocess.call in the source that could potentially be replaced with os or shutil functions. Is there a reason for the use of subprocess.call other than to suppress exceptions if the operations fail?