### PR TITLE
Display objects correctly as strings in log

### DIFF
--- a/tangoObjects.py
+++ b/tangoObjects.py
@@ -30,6 +30,10 @@ class InputFile():
         self.localFile = localFile
         self.destFile = destFile
 
+    def __repr__(self):
+        return "InputFile(localFile: %s, destFile: %s)" % (self.localFile, 
+                self.destFile)
+
 
 class TangoMachine():
 
@@ -53,6 +57,9 @@ class TangoMachine():
         self.resume = resume
         self.id = id
         self.instance_id = id
+
+    def __repr__(self):
+        return "TangoMachine(image: %s, vmms: %s)" % (self.image, self.vmms)
 
 
 class TangoJob():


### PR DESCRIPTION
Previous log example:    

    INFO|2015-09-27 16:53:03,868|JobQueue|Job details: {'retries': 0, 
    'outputFile': u'/Users/yashaskumar/Desktop/cmuSCS/autolab/courselabs/test-log/output/result.out-1',
    'name': u'test_job-1', 'trace': [u'Sun Sep 27 20:53:03 2015|Added job test_job-1:1 to queue'], 
    'notifyURL': None, 'maxOutputFileSize': 1024000, '_remoteLocation': None, 
    'vm': <tangoObjects.TangoMachine instance at 0x10cca34d0>, 'assigned': False, 'timeout': 60, 
    'input': [<tangoObjects.InputFile instance at 0x10cca3440>, <tangoObjects.InputFile instance at 0x10cca3488>], 
    'id': 1}

New log example:

    INFO|2015-09-27 17:20:49,146|JobQueue|Job details: {'retries': 0, 
    'outputFile': u'/Users/yashaskumar/Desktop/cmuSCS/autolab/courselabs/test-yrkumar/output/result.out-1', 
    'name': u'test_job-1', 'trace': [u'Sun Sep 27 21:20:49 2015|Added job test_job-1:1 to queue'], 
    'notifyURL': None, 'maxOutputFileSize': 1024000, '_remoteLocation': None, 
    'vm': TangoMachine(image: autograding_image, vmms: localDocker), 'assigned': False, 'timeout': 60, 
    'input': [InputFile(localFile: /Users/yashaskumar/Desktop/cmuSCS/autolab/courselabs/test-yrkumar/autograde-Makefile, destFile: Makefile), InputFile(localFile: /Users/yashaskumar/Desktop/cmuSCS/autolab/courselabs/test-yrkumar/hello.sh, destFile: hello.sh)], 
    'id': 1}

Note that the `vm` and `input` fields are displayed correctly now.