### PR TITLE
Refresh the job dict in Redis after editing the job retries

### DIFF
--- a/jobQueue.py
+++ b/jobQueue.py
@@ -241,14 +241,14 @@ class JobQueue:
         self.queueLock.acquire()
         self.log.debug("unassignJob| Acquired lock to job queue.")
         job = self.liveJobs.get(jobId)
-        self.log.info("unassignJob|Unassigning job %s" % str(job.id))
-        job.makeUnassigned()
         if job.retries is None:
             job.retries = 0
         else:
             job.retries += 1
             Config.job_retries += 1
 
+        self.log.info("unassignJob|Unassigning job %s" % str(job.id))
+        job.makeUnassigned()
         self.queueLock.release()
         self.log.debug("unassignJob| Released lock to job queue.")
 


### PR DESCRIPTION
VM becomes unrecoverable after OS error and the job churns through VMs, rescheduling the job infinitely. The issue is that after retrying the job, we update `job.retries` but don't refresh the job entry in Redis, so the next time the job is assigned, `job.retries` remains the old version.