### PR TITLE
Return the correct result on create

### DIFF
--- a/restful-tango/tangoREST.py
+++ b/restful-tango/tangoREST.py
@@ -242,7 +242,7 @@ class TangoREST:
                     self.log.info(
                         "Created directory for (%s, %s)" % (key, courselab))
                     statusObj = self.status.made_dir
-                    statusObj["files"] = []
+                    statusObj["files"] = {}
                     return statusObj
             except Exception as e:
                 self.log.error("open request failed: %s" % str(e))


### PR DESCRIPTION
when open creates a directory, return an empty hash/object,
not an empty array, so as to behave the same as when the directory
already exists (as changed in #86)