### PR TITLE
Reorganization

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Upon receiving a job, Tango will copy all of the job's input files into a VM, ru
 
 A brief overview of the Tango respository:
 
-* `tangod.py` - Main tango server
+* `tango.py` - Main tango server
 * `jobQueue.py` - Manages the job queue
 * `jobManager.py` - Assigns jobs to free VMs
 * `worker.py` - Shepherds a job through its execution

--- a/config.template.py
+++ b/config.template.py
@@ -2,8 +2,7 @@
 # config.py - Global configuration constants and runtime info
 #
 
-import logging
-import time
+import logging, time
 
 # Config - defines
 

--- a/jobManager.py
+++ b/jobManager.py
@@ -17,7 +17,7 @@ from worker import Worker
 from jobQueue import JobQueue
 from preallocator import Preallocator
 from tangoObjects import TangoQueue
-from tangod import *
+from tango import *
 
 class JobManager:
 

--- a/jobQueue.py
+++ b/jobQueue.py
@@ -7,11 +7,11 @@
 # JobManager: Class that creates a thread object that looks for new
 # work on the job queue and assigns it to workers.
 #
-import time, threading, logging
+import threading, logging, time
 
 from datetime import datetime
-from config import Config
 from tangoObjects import TangoDictionary, TangoJob
+from config import Config
 
 #
 # JobQueue - This class defines the job queue and the functions for
@@ -79,7 +79,7 @@ class JobQueue:
             self.log.info("add|JobQueue is full")
             return -1
         self.log.debug("add|Gotten next ID: " + str(job.id))
-        self.log.info("add|Unassigning job %s" % str(job.id))
+        self.log.info("add|Unassigning job ID: %d" % (job.id))
         job.makeUnassigned()
         job.retries = 0
 
@@ -100,9 +100,8 @@ class JobQueue:
         self.queueLock.release()
         self.log.debug("add|Releasing lock to job queue.")
 
-        self.log.info("Added job %s:%d to queue" % (job.name, job.id))
-        self.log.info("Job id: " + str(job.id))
-        self.log.info("Job details: " + str(job.__dict__))
+        self.log.info("Added job %s:%d to queue, details = %s" % 
+            (job.name, job.id, str(job.__dict__)))
 
         return str(job.id)
 
@@ -228,7 +227,7 @@ class JobQueue:
         self.log.debug("assignJob| Acquired lock to job queue.")
         job = self.liveJobs.get(jobId)
         self.log.debug("assignJob| Retrieved job.")
-        self.log.info("assignJob|Assigning job %s" % str(job.id))
+        self.log.info("assignJob|Assigning job ID: %s" % str(job.id))
         job.makeAssigned()
 
         self.log.debug("assignJob| Releasing lock to job queue.")
@@ -255,12 +254,12 @@ class JobQueue:
     def makeDead(self, id, reason):
         """ makeDead - move a job from live queue to dead queue
         """
-        self.log.info("makeDead| Making dead: " + str(id))
+        self.log.info("makeDead| Making dead job ID: " + str(id))
         self.queueLock.acquire()
         self.log.debug("makeDead| Acquired lock to job queue.")
         status = -1
         if str(id) in self.liveJobs.keys():
-            self.log.info("makeDead| Job is in the queue")
+            self.log.info("makeDead| Found job ID: %d in the live queue" % (id))
             status = 0
             job = self.liveJobs.get(id)
             self.log.info("Terminated job %s:%d: %s" %

--- a/preallocator.py
+++ b/preallocator.py
@@ -1,10 +1,8 @@
 #
 # preallocator.py - maintains a pool of active virtual machines
 #
-import threading
-import logging
-import copy
-import time
+import threading, logging, time, copy
+
 from tangoObjects import TangoDictionary, TangoQueue, TangoIntValue
 from config import Config
 

--- a/restful-tango/server.py
+++ b/restful-tango/server.py
@@ -143,6 +143,6 @@ if __name__ == "__main__":
     if len(sys.argv) > 1:
         port = int(sys.argv[1])
 
-    tangoREST.tango.resetTango(tangoREST.tango.vmms)
+    tangoREST.tango.resetTango(tangoREST.tango.preallocator.vmms)
     application.listen(port, max_buffer_size=Config.MAX_INPUT_FILE_SIZE)
     tornado.ioloop.IOLoop.instance().start()

--- a/restful-tango/tangoREST.py
+++ b/restful-tango/tangoREST.py
@@ -11,12 +11,7 @@ import hashlib
 import json
 import logging
 
-currentdir = os.path.dirname(
-    os.path.abspath(inspect.getfile(inspect.currentframe())))
-parentdir = os.path.dirname(currentdir)
-sys.path.insert(0, parentdir)
-
-from tangod import TangoServer
+from tango import TangoServer
 from tangoObjects import TangoJob, TangoMachine, InputFile
 
 from config import Config

--- a/restful-tango/tangoREST.py
+++ b/restful-tango/tangoREST.py
@@ -294,7 +294,7 @@ class TangoREST:
                 if (jobId == -1):
                     self.log.info("Failed to add job to tango")
                     return self.status.create(-1, job.trace)
-                self.log.info("Successfully added job to tango")
+                self.log.info("Successfully added job ID: %s to tango" % str(jobId))
                 result = self.status.job_added
                 result['jobId'] = jobId
                 return result

--- a/scripts/sourcelib
+++ b/scripts/sourcelib
@@ -1,7 +1,0 @@
-#!/bin/bash
-#
-# Run this script from tango3 directory
-# For RESTful Tango
-tango3_dir=$PWD
-export PYTHONPATH=$tango3_dir:$tango3_dir/lib/futures-2.2.0/:$tango3_dir/lib/backports.ssl_match_hostname-3.4.0.2/src/:$tango3_dir/lib/boto-2.27.0/:$tango3_dir/lib/requests-2.2.1/:$tango3_dir/lib/tornado-3.2/:/usr/share/tashi/src/:$PYTHONPATH
-

--- a/tango.py
+++ b/tango.py
@@ -10,7 +10,7 @@
 # 2. The TangoServer Class: This is a class that accepts addJob requests
 #    from the restful server. Job requests are validated and placed in
 #    a job queue. This class also implements various administrative
-#    functions to manage instances of tangoServer. (tangod.py)
+#    functions to manage instances of tangoServer. (tango.py)
 #
 # 3. The Job Manager: This thread runs continuously. It watches the job
 #    queue for new job requests. When it finds one it creates a new
@@ -85,9 +85,9 @@ class TangoServer:
             format="%(levelname)s|%(asctime)s|%(name)s|%(message)s",
             level=Config.LOGLEVEL,
         )
-        self.log = logging.getLogger("Tangod")
-        self.log.info("Starting Tango server on port %d" % (Config.PORT))
         self.start_time = time.time()
+        self.log = logging.getLogger("TangoServer")
+        self.log.info("Starting Tango server")
 
     def addJob(self, job):
         """ addJob - Add a job to the job queue


### PR DESCRIPTION
This PR has 3 major changes:
1. Adds module structure so we can use import statements in subdirectories without having to programmatically add to the system `PATH`. This means that we now start Tango using the following command from the shell: `python -m restful-tango.server`. These changes are in 268075e. 
2. Removes duplicate dependencies in Tango (i.e. `jobManager` requires only `jobQueue` to initialize since `preallocator` and `vmms` are stored in `jobQueue`). These changes are in 85b435c.
3. Renames `tangod.py` to `tango.py` and adds extra logging information that will help identify a job by its ID in the logs. 

Tested locally with `localDocker` vmms to make sure everything is still working. 
