### PR TITLE
Add extra status message to handle empty pool request. Fixes #84

### DIFF
--- a/clients/tango-rest.py
+++ b/clients/tango-rest.py
@@ -51,7 +51,7 @@ parser.add_argument(
 
 parser.add_argument('--vmms', default='localDocker',
                     help='Choose vmms between ec2SSH, tashiSSH, localDocker, and distDocker')
-parser.add_argument('--image', default='autograding_image',
+parser.add_argument('--image', default='',
                     help='VM image name (default "autograding_image")')
 parser.add_argument(
     '--infiles',


### PR DESCRIPTION
Handle empty pool request (when no image is specified) by adding a new status message that does not result in an error code. 