### PR TITLE
Add nginx and docker to supervisor with instructions to autostart

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,7 +65,6 @@ RUN cp /opt/TangoService/Tango/deployment/config/nginx.conf /etc/nginx/nginx.con
 RUN cp /opt/TangoService/Tango/deployment/config/supervisord.conf /etc/supervisor/supervisord.conf
 RUN cp /opt/TangoService/Tango/deployment/config/redis.conf /etc/redis.conf
 
-EXPOSE 8600
 # Reload new config scripts
 CMD ["/usr/bin/supervisord", "-c", "/etc/supervisor/supervisord.conf"]
 

--- a/clients/tango-rest.py
+++ b/clients/tango-rest.py
@@ -128,7 +128,7 @@ def tango_open():
             raise Exception("Invalid usage: [open] " + open_help)
 
         response = requests.get(
-            '%s:%d/open/%s/%s/' %
+            'http://%s:%d/open/%s/%s/' %
             (args.server, args.port, args.key, args.courselab))
         print "Sent request to %s:%d/open/%s/%s/" % (args.server, args.port, args.key, args.courselab)
         print response.content
@@ -153,7 +153,7 @@ def tango_upload():
         header = {'Filename': filename}
 
         response = requests.post(
-            '%s:%d/upload/%s/%s/' %
+            'http://%s:%d/upload/%s/%s/' %
             (args.server,
              args.port,
              args.key,
@@ -189,7 +189,7 @@ def tango_addJob():
             requestObj['notifyURL'] = args.notifyURL
 
         response = requests.post(
-            '%s:%d/addJob/%s/%s/' %
+            'http://%s:%d/addJob/%s/%s/' %
             (args.server,
              args.port,
              args.key,
@@ -213,7 +213,7 @@ def tango_poll():
             raise Exception("Invalid usage: [poll] " + poll_help)
 
         response = requests.get(
-            '%s:%d/poll/%s/%s/%s/' %
+            'http://%s:%d/poll/%s/%s/%s/' %
             (args.server,
              args.port,
              args.key,
@@ -238,7 +238,7 @@ def tango_info():
             raise Exception("Invalid usage: [info] " + info_help)
 
         response = requests.get(
-            '%s:%d/info/%s/' % (args.server, args.port, args.key))
+            'http://%s:%d/info/%s/' % (args.server, args.port, args.key))
         print "Sent request to %s:%d/info/%s/" % (args.server, args.port, args.key)
         print response.content
 
@@ -257,7 +257,7 @@ def tango_jobs():
             raise Exception("Invalid usage: [jobs] " + jobs_help)
 
         response = requests.get(
-            '%s:%d/jobs/%s/%d/' %
+            'http://%s:%d/jobs/%s/%d/' %
             (args.server, args.port, args.key, args.deadJobs))
         print "Sent request to %s:%d/jobs/%s/%d/" % (args.server, args.port, args.key, args.deadJobs)
         print response.content
@@ -276,7 +276,7 @@ def tango_pool():
         if res != 0:
             raise Exception("Invalid usage: [pool] " + pool_help)
 
-        response = requests.get('%s:%d/pool/%s/%s/' %
+        response = requests.get('http://%s:%d/pool/%s/%s/' %
                                 (args.server, args.port, args.key, args.image))
         print "Sent request to %s:%d/pool/%s/%s/" % (args.server, args.port, args.key, args.image)
         print response.content
@@ -301,7 +301,7 @@ def tango_prealloc():
         vmObj['memory'] = args.memory
 
         response = requests.post(
-            '%s:%d/prealloc/%s/%s/%s/' %
+            'http://%s:%d/prealloc/%s/%s/%s/' %
             (args.server,
              args.port,
              args.key,
@@ -388,7 +388,7 @@ if (not args.open and not args.upload and not args.addJob
     sys.exit(0)
 
 try:
-    response = requests.get('%s:%d/' % (args.server, args.port))
+    response = requests.get('http://%s:%d/' % (args.server, args.port))
 except:
     print 'Tango not reachable on %s:%d!\n' % (args.server, args.port)
     sys.exit(0)

--- a/deployment/config/nginx.conf
+++ b/deployment/config/nginx.conf
@@ -1,6 +1,7 @@
 
 #user  nobody;
 worker_processes  1;
+daemon off;
 
 #error_log  logs/error.log;
 #error_log  logs/error.log  notice;

--- a/deployment/config/supervisord.conf
+++ b/deployment/config/supervisord.conf
@@ -1,22 +1,9 @@
-; Sample supervisor config file.
-;
-; For more information on the config file, please see:
-; http://supervisord.org/configuration.html
-;
-; Notes:
-;  - Shell expansion ("~" or "$HOME") is not supported.  Environment
-;    variables can be expanded using this syntax: "%(ENV_HOME)s".
-;  - Comments must have a leading space: "a=b ;comment" not "a=b;comment".
+; Supervisor config file.
 
 [unix_http_server]
 file=/tmp/supervisor.sock   ; (the path to the socket file)
 ;chmod=0700                 ; socket file mode (default 0700)
 ;chown=nobody:nogroup       ; socket file uid:gid owner
-;username=user              ; (default is no username (open server))
-;password=123               ; (default is no password (open server))
-
-;[inet_http_server]         ; inet (TCP) server disabled by default
-;port=127.0.0.1:9001        ; (ip_address:port specifier, *:port for all iface)
 ;username=user              ; (default is no username (open server))
 ;password=123               ; (default is no password (open server))
 
@@ -26,7 +13,7 @@ logfile_maxbytes=50MB        ; (max main logfile bytes b4 rotation;default 50MB)
 logfile_backups=10           ; (num of main logfile rotation backups;default 10)
 loglevel=info                ; (log level;default info; others: debug,warn,trace)
 pidfile=/tmp/supervisord.pid ; (supervisord pidfile;default supervisord.pid)
-nodaemon=false               ; (start in foreground if true;default false)
+nodaemon=true                ; (start in foreground if true;default false)
 minfds=1024                  ; (min. avail startup file descriptors;default 1024)
 minprocs=200                 ; (min. avail process descriptors;default 200)
 ;umask=022                   ; (process file creation umask;default 022)
@@ -52,111 +39,42 @@ serverurl=unix:///tmp/supervisor.sock ; use a unix:// URL  for a unix socket
 ;prompt=mysupervisor         ; cmd line prompt (default "supervisor")
 ;history_file=~/.sc_history  ; use readline history if available
 
-; The below sample program section shows all possible program subsection values,
-; create one or more 'real' program: sections to be able to control them under
-; supervisor.
-
-;[program:theprogramname]
-;command=/bin/cat              ; the program (relative uses PATH, can take args)
-;process_name=%(program_name)s ; process_name expr (default %(program_name)s)
-;numprocs=1                    ; number of processes copies to start (def 1)
-;directory=/tmp                ; directory to cwd to before exec (def no cwd)
-;umask=022                     ; umask for process (default None)
-;priority=999                  ; the relative start priority (default 999)
-;autostart=true                ; start at supervisord start (default: true)
-;autorestart=unexpected        ; whether/when to restart (default: unexpected)
-;startsecs=1                   ; number of secs prog must stay running (def. 1)
-;startretries=3                ; max # of serial start failures (default 3)
-;exitcodes=0,2                 ; 'expected' exit codes for process (default 0,2)
-;stopsignal=QUIT               ; signal used to kill process (default TERM)
-;stopwaitsecs=10               ; max num secs to wait b4 SIGKILL (default 10)
-;stopasgroup=false             ; send stop signal to the UNIX process group (default false)
-;killasgroup=false             ; SIGKILL the UNIX process group (def false)
-;user=chrism                   ; setuid to this UNIX account to run the program
-;redirect_stderr=true          ; redirect proc stderr to stdout (default false)
-;stdout_logfile=/a/path        ; stdout log path, NONE for none; default AUTO
-;stdout_logfile_maxbytes=1MB   ; max # logfile bytes b4 rotation (default 50MB)
-;stdout_logfile_backups=10     ; # of stdout logfile backups (default 10)
-;stdout_capture_maxbytes=1MB   ; number of bytes in 'capturemode' (default 0)
-;stdout_events_enabled=false   ; emit events on stdout writes (default false)
-;stderr_logfile=/a/path        ; stderr log path, NONE for none; default AUTO
-;stderr_logfile_maxbytes=1MB   ; max # logfile bytes b4 rotation (default 50MB)
-;stderr_logfile_backups=10     ; # of stderr logfile backups (default 10)
-;stderr_capture_maxbytes=1MB   ; number of bytes in 'capturemode' (default 0)
-;stderr_events_enabled=false   ; emit events on stderr writes (default false)
-;environment=A="1",B="2"       ; process environment additions (def no adds)
-;serverurl=AUTO                ; override serverurl computation (childutils)
-
-; The below sample eventlistener section shows all possible
-; eventlistener subsection values, create one or more 'real'
-; eventlistener: sections to be able to handle event notifications
-; sent by supervisor.
-
-;[eventlistener:theeventlistenername]
-;command=/bin/eventlistener    ; the program (relative uses PATH, can take args)
-;process_name=%(program_name)s ; process_name expr (default %(program_name)s)
-;numprocs=1                    ; number of processes copies to start (def 1)
-;events=EVENT                  ; event notif. types to subscribe to (req'd)
-;buffer_size=10                ; event buffer queue size (default 10)
-;directory=/tmp                ; directory to cwd to before exec (def no cwd)
-;umask=022                     ; umask for process (default None)
-;priority=-1                   ; the relative start priority (default -1)
-;autostart=true                ; start at supervisord start (default: true)
-;autorestart=unexpected        ; whether/when to restart (default: unexpected)
-;startsecs=1                   ; number of secs prog must stay running (def. 1)
-;startretries=3                ; max # of serial start failures (default 3)
-;exitcodes=0,2                 ; 'expected' exit codes for process (default 0,2)
-;stopsignal=QUIT               ; signal used to kill process (default TERM)
-;stopwaitsecs=10               ; max num secs to wait b4 SIGKILL (default 10)
-;stopasgroup=false             ; send stop signal to the UNIX process group (default false)
-;killasgroup=false             ; SIGKILL the UNIX process group (def false)
-;user=chrism                   ; setuid to this UNIX account to run the program
-;redirect_stderr=true          ; redirect proc stderr to stdout (default false)
-;stdout_logfile=/a/path        ; stdout log path, NONE for none; default AUTO
-;stdout_logfile_maxbytes=1MB   ; max # logfile bytes b4 rotation (default 50MB)
-;stdout_logfile_backups=10     ; # of stdout logfile backups (default 10)
-;stdout_events_enabled=false   ; emit events on stdout writes (default false)
-;stderr_logfile=/a/path        ; stderr log path, NONE for none; default AUTO
-;stderr_logfile_maxbytes=1MB   ; max # logfile bytes b4 rotation (default 50MB)
-;stderr_logfile_backups        ; # of stderr logfile backups (default 10)
-;stderr_events_enabled=false   ; emit events on stderr writes (default false)
-;environment=A="1",B="2"       ; process environment additions
-;serverurl=AUTO                ; override serverurl computation (childutils)
-
-; The below sample group section shows all possible group values,
-; create one or more 'real' group: sections to create "heterogeneous"
-; process groups.
-
-;[group:thegroupname]
-;programs=progname1,progname2  ; each refers to 'x' in [program:x] definitions
-;priority=999                  ; the relative start priority (default 999)
-
-; The [include] section can just contain the "files" setting.  This
-; setting can list multiple files (separated by whitespace or
-; newlines).  It can also contain wildcards.  The filenames are
-; interpreted as relative to this file.  Included files *cannot*
-; include files themselves.
-
-;[include]
-;files = relative/directory/*.ini
-
 [program:redis_server]
 command=/usr/local/bin/redis-server /etc/redis.conf
-autostart=false
+priority=1
+autostart=true
 autorestart=false
 user=root
 stdout_logfile=/var/log/redis_stdout.log
 stderr_logfile=/var/log/redis_stderr.log
 
+[program:nginx]
+command=/usr/sbin/nginx -c /etc/nginx/nginx.conf
+autostart=true
+autorestart=true
+stdout_events_enabled=true
+stderr_events_enabled=true
+
+[program:docker]
+command=/usr/bin/docker daemon
+autostart=true
+autorestart=true
+user=root
+redirect_stderr=true
+stdout_logfile=/var/log/docker/%(program_name)s.log
+stdout_logfile_maxbytes=10MB
+stdout_logfile_backups=10
 
 [program:tango]
-command=python /opt/TangoService/Tango/restful-tango/server.py 861%(process_num)01d
+command=/bin/bash -c 'sleep 5 && python /opt/TangoService/Tango/restful-tango/server.py 861%(process_num)01d'
+autostart=true
 process_name=%(process_num)01d
 redirect_stderr=true
 stdout_logfile=/opt/TangoService/tango_log.log.%(process_num)01d
 numprocs=2
 
 [program:tangoJobManager]
-command=python /opt/TangoService/Tango/jobManager.py
+command=/bin/bash -c 'sleep 5 && python /opt/TangoService/Tango/jobManager.py'
+autostart=true
 redirect_stderr=true
 stdout_logfile=/opt/TangoService/tango_job_manager_log.log

--- a/deployment/config/supervisord.conf
+++ b/deployment/config/supervisord.conf
@@ -55,8 +55,8 @@ autorestart=true
 stdout_events_enabled=true
 stderr_events_enabled=true
 
-[program:docker]
-command=/usr/bin/docker daemon
+[program:wrapdocker]
+command=/usr/local/bin/wrapdocker
 autostart=true
 autorestart=true
 user=root

--- a/wrapdocker
+++ b/wrapdocker
@@ -90,14 +90,14 @@ rm -rf /var/run/docker.pid
 # otherwise, spawn a shell as well
 if [ "$PORT" ]
 then
-	exec docker -d -H 0.0.0.0:$PORT -H unix:///var/run/docker.sock \
+	exec docker daemon -H 0.0.0.0:$PORT -H unix:///var/run/docker.sock \
 		$DOCKER_DAEMON_ARGS
 else
 	if [ "$LOG" == "file" ]
 	then
-		docker -d $DOCKER_DAEMON_ARGS &>/var/log/docker.log &
+		docker daemon $DOCKER_DAEMON_ARGS &>/var/log/docker.log &
 	else
-		docker -d $DOCKER_DAEMON_ARGS &
+		docker daemon $DOCKER_DAEMON_ARGS &
 	fi
 	(( timeout = 60 + SECONDS ))
 	until docker info >/dev/null 2>&1


### PR DESCRIPTION
This addresses some parts of #121. More specifically, it adds nginx and docker to supervisor. Exposing the ports of the Tango service in the docker container simply involves adding extra params when running the docker container so that has been added to the [suggested deployment documentation](https://github.com/autolab/Tango/wiki/Suggested-Deployment).