### PR TITLE
Ec2 bug fixes

### DIFF
--- a/config.template.py
+++ b/config.template.py
@@ -135,6 +135,7 @@ class Config:
     # Part 5: EC2 Constants
     #
     EC2_REGION = ''
+    EC2_USER_NAME = ''
     DEFAULT_AMI = ''
     DEFAULT_INST_TYPE = ''
     DEFAULT_SECURITY_GROUP = ''

--- a/vmms/ec2SSH.py
+++ b/vmms/ec2SSH.py
@@ -227,35 +227,35 @@ class Ec2SSH:
                 if (elapsed_secs > max_secs):
                     return -1
 
-            # The ping worked, so now wait for SSH to work before
-            # declaring that the VM is ready
-            self.log.debug("VM %s: ping completed" % (vm.name))
-            while(True):
+        # The ping worked, so now wait for SSH to work before
+        # declaring that the VM is ready
+        self.log.debug("VM %s: ping completed" % (vm.name))
+        while(True):
 
-                elapsed_secs = time.time() - start_time
+            elapsed_secs = time.time() - start_time
 
-                # Give up if the elapsed time exceeds the allowable time
-                if elapsed_secs > max_secs:
-                    self.log.info(
-                        "VM %s: SSH timeout after %d secs" %
-                        (instanceName, elapsed_secs))
-                    return -1
+            # Give up if the elapsed time exceeds the allowable time
+            if elapsed_secs > max_secs:
+                self.log.info(
+                    "VM %s: SSH timeout after %d secs" %
+                    (instanceName, elapsed_secs))
+                return -1
 
-                # If the call to ssh returns timeout (-1) or ssh error
-                # (255), then success. Otherwise, keep trying until we run
-                # out of time.
-                ret = timeout(["ssh"] + Ec2SSH._SSH_FLAGS +
-                              ["%s@%s" % (config.Config.EC2_USER_NAME, domain_name),
-                               "(:)"], max_secs - elapsed_secs)
+            # If the call to ssh returns timeout (-1) or ssh error
+            # (255), then success. Otherwise, keep trying until we run
+            # out of time.
+            ret = timeout(["ssh"] + Ec2SSH._SSH_FLAGS +
+                          ["%s@%s" % (config.Config.EC2_USER_NAME, domain_name),
+                           "(:)"], max_secs - elapsed_secs)
 
-                self.log.debug("VM %s: ssh returned with %d" %
-                               (instanceName, ret))
+            self.log.debug("VM %s: ssh returned with %d" %
+                           (instanceName, ret))
 
-                if (ret != -1) and (ret != 255):
-                    return 0
+            if (ret != -1) and (ret != 255):
+                return 0
 
-                # Sleep a bit before trying again
-                time.sleep(config.Config.TIMER_POLL_INTERVAL)
+            # Sleep a bit before trying again
+            time.sleep(config.Config.TIMER_POLL_INTERVAL)
 
     def copyIn(self, vm, inputFiles):
         """ copyIn - Copy input files to VM
@@ -335,7 +335,7 @@ class Ec2SSH:
                 pass
 
         return timeout(["scp"] + Ec2SSH._SSH_FLAGS +
-                       ["%s@%s" % (config.Config.EC2_USER_NAME, domain_name), destFile],
+                       ["%s@%s:output" % (config.Config.EC2_USER_NAME, domain_name), destFile],
                        config.Config.COPYOUT_TIMEOUT)
 
     def destroyVM(self, vm):

--- a/worker.py
+++ b/worker.py
@@ -108,7 +108,7 @@ class Worker(threading.Thread):
         """
         f = open(filename, "a")
         f.write("Autograder [%s]: %s\n" % (datetime.now().ctime(), msg))
-        f.close
+        f.close()
 
     def catFiles(self, f1, f2):
         """ catFiles - cat f1 f2 > f2, where f1 is the Tango header
@@ -125,7 +125,7 @@ class Worker(threading.Thread):
                 shutil.copyfileobj(f2fd, wf)
         except OSError:
             pass
-        wf.close
+        wf.close()
         os.rename(tmpname, f2)
         os.remove(f1)
 


### PR DESCRIPTION
I tried the setup guide and testing guide, but it only works after fixing the following four bugs:
1. The indent for destroyVM
2. Add a temporary getImages method (it actually doesn't need this method)
3. Change t1.micro to t2.micro. It seems that there isn't t1.micro instance.
4. When we ssh to an AWS, the user name can be ec2-user or root instead of ubuntu. But this is hard-coded. See http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AccessingInstancesLinux.html.