### PR TITLE
Allow Autolab front-end to specify the AWS credentials that are used in auto-grading

### DIFF
--- a/clients/tango-rest.py
+++ b/clients/tango-rest.py
@@ -201,7 +201,6 @@ def tango_addJob():
         requestObj['accessKeyId'] = args.accessKeyId
         requestObj['accessKey'] = args.accessKey
 
-        print "Sent request to %s:%d/addJob/%s/%s/ \t jobObj=%s" % (args.server, args.port, args.key, args.courselab, json.dumps(requestObj))
         response = requests.post(
             'http://%s:%d/addJob/%s/%s/' %
             (args.server,
@@ -209,6 +208,7 @@ def tango_addJob():
              args.key,
              args.courselab),
             data=json.dumps(requestObj))
+        print "Sent request to %s:%d/addJob/%s/%s/ \t jobObj=%s" % (args.server, args.port, args.key, args.courselab, json.dumps(requestObj))
         print response.content
 
     except Exception as err:

--- a/clients/tango-rest.py
+++ b/clients/tango-rest.py
@@ -83,6 +83,15 @@ parser.add_argument(
     '--notifyURL',
     help='Complete URL for Tango to give callback to once job is complete.')
 
+# add for aws student accounts
+parser.add_argument(
+    '--accessKeyId', default='',
+    help='AWS account access key ID')
+
+parser.add_argument(
+    '--accessKey', default='',
+    help='AWS account access key content')
+
 
 def checkKey():
     if (args.key is None):
@@ -185,9 +194,14 @@ def tango_addJob():
         requestObj['max_kb'] = args.maxsize
         requestObj['output_file'] = args.outputFile
         requestObj['jobName'] = args.jobname
+        
         if (args.notifyURL):
             requestObj['notifyURL'] = args.notifyURL
+        
+        requestObj['accessKeyId'] = args.accessKeyId
+        requestObj['accessKey'] = args.accessKey
 
+        print "Sent request to %s:%d/addJob/%s/%s/ \t jobObj=%s" % (args.server, args.port, args.key, args.courselab, json.dumps(requestObj))
         response = requests.post(
             '%s:%d/addJob/%s/%s/' %
             (args.server,
@@ -195,7 +209,6 @@ def tango_addJob():
              args.key,
              args.courselab),
             data=json.dumps(requestObj))
-        print "Sent request to %s:%d/addJob/%s/%s/ \t jobObj=%s" % (args.server, args.port, args.key, args.courselab, json.dumps(requestObj))
         print response.content
 
     except Exception as err:

--- a/config.template.py
+++ b/config.template.py
@@ -140,6 +140,7 @@ class Config:
     DEFAULT_INST_TYPE = ''
     DEFAULT_SECURITY_GROUP = ''
     SECURITY_KEY_PATH = ''
+    DYNAMIC_SECURITY_KEY_PATH = ''
     SECURITY_KEY_NAME = ''
     TANGO_RESERVATION_ID = ''
     INSTANCE_RUNNING = 16  # Status code of a instance that is running

--- a/config.template.py
+++ b/config.template.py
@@ -135,6 +135,7 @@ class Config:
     # Part 5: EC2 Constants
     #
     EC2_REGION = ''
+    EC2_USER_NAME = ''
     DEFAULT_AMI = ''
     DEFAULT_INST_TYPE = ''
     DEFAULT_SECURITY_GROUP = ''

--- a/jobManager.py
+++ b/jobManager.py
@@ -58,7 +58,7 @@ class JobManager:
                 try:
                     # Mark the job assigned
                     self.jobQueue.assignJob(job.id)
-                    # if the has specified an account
+                    # if the job has specified an account
                     # create an VM on the account and run on that instance
                     if job.accessKeyId:
                         from vmms.ec2SSH import Ec2SSH

--- a/jobManager.py
+++ b/jobManager.py
@@ -44,28 +44,35 @@ class JobManager:
 
     def __manage(self):
         self.running = True
+        # job-associated instance id
+        nextId = 10000
         while True:
             id = self.jobQueue.getNextPendingJob()
 
             if id:
                 job = self.jobQueue.get(id)
-                if not job.accessKey or Config.REUSE_VMS:
+                if not job.accessKey and Config.REUSE_VMS:
                     id, vm = self.jobQueue.getNextPendingJobReuse(id)
                     job = self.jobQueue.get(id)
 
                 try:
                     # Mark the job assigned
                     self.jobQueue.assignJob(job.id)
-
-                    # Try to find a vm on the free list and allocate it to
-                    # the worker if successful.
+                    # if the has specified an account
+                    # create an VM on the account and run on that instance
                     if job.accessKeyId:
                         from vmms.ec2SSH import Ec2SSH
                         vmms = Ec2SSH(job.accessKeyId, job.accessKey)
                         newVM = copy.deepcopy(job.vm)
-                        newVM.id = 2000
+                        newVM.id = nextId
                         preVM = vmms.initializeVM(newVM)
+                        if nextId > 99999:
+                            nextId = 1000
+                        else:
+                            nextId += 1
                     else:
+                        # Try to find a vm on the free list and allocate it to
+                        # the worker if successful.
                         if Config.REUSE_VMS:
                             preVM = vm
                         else:

--- a/jobQueue.py
+++ b/jobQueue.py
@@ -198,13 +198,15 @@ class JobQueue:
         self.queueLock.release()
         return None
 
-    def getNextPendingJobReuse(self):
+    def getNextPendingJobReuse(self, target_id=None):
         """getNextPendingJobReuse - Returns ID of next pending job and its VM.
         Called by JobManager when Config.REUSE_VMS==True
         """
         self.queueLock.acquire()
         for id, job in self.liveJobs.iteritems():
-
+            # if target_id is set, only interested in this id
+            if target_id and target_id != id:
+                continue
             # Create a pool if necessary
             if self.preallocator.poolSize(job.vm.name) == 0:
                 self.preallocator.update(job.vm, Config.POOL_SIZE)

--- a/restful-tango/tangoREST.py
+++ b/restful-tango/tangoREST.py
@@ -156,6 +156,13 @@ class TangoREST:
         # VM object
         vm = self.createTangoMachine(jobObj["image"])
 
+        # for backward compatibility
+        accessKeyId = None
+        accessKey = None
+        if "accessKey" in jobObj and len(jobObj["accessKey"]) > 0:
+            accessKeyId = jobObj["accessKeyId"]
+            accessKey = jobObj["accessKey"]
+
         job = TangoJob(
             name=name,
             vm=vm,
@@ -163,7 +170,10 @@ class TangoREST:
             input=input,
             timeout=timeout,
             notifyURL=notifyURL,
-            maxOutputFileSize=maxOutputFileSize)
+            maxOutputFileSize=maxOutputFileSize,
+            accessKey=accessKey,
+            accessKeyId=accessKeyId
+        )
 
         self.log.debug("inputFiles: %s" % [file.localFile for file in input])
         self.log.debug("outputFile: %s" % outputFile)

--- a/tangoObjects.py
+++ b/tangoObjects.py
@@ -71,7 +71,8 @@ class TangoJob():
     def __init__(self, vm=None,
                  outputFile=None, name=None, input=None,
                  notifyURL=None, timeout=0,
-                 maxOutputFileSize=Config.MAX_OUTPUT_FILE_SIZE):
+                 maxOutputFileSize=Config.MAX_OUTPUT_FILE_SIZE,
+                 accessKeyId=None, accessKey=None):
         self.assigned = False
         self.retries = 0
 
@@ -88,6 +89,8 @@ class TangoJob():
         self.trace = []
         self.maxOutputFileSize = maxOutputFileSize
         self._remoteLocation = None
+        self.accessKeyId = accessKeyId
+        self.accessKey = accessKey
 
     def makeAssigned(self):
         self.syncRemote()

--- a/vmms/ec2SSH.py
+++ b/vmms/ec2SSH.py
@@ -111,9 +111,7 @@ class Ec2SSH:
         return "%s-%d-%s" % (config.Config.PREFIX, id, name)
 
     def keyPairName(self, id, name):
-        """ instanceName - Constructs a VM instance name. Always use
-        this function when you need a VM instance name. Never generate
-        instance names manually.
+        """ keyPairName - Constructs a unique key pair name.
         """
         return "%s-%d-%s" % (config.Config.PREFIX, id, name)
 

--- a/vmms/ec2SSH.py
+++ b/vmms/ec2SSH.py
@@ -292,8 +292,9 @@ class Ec2SSH:
                                                config.Config.VM_ULIMIT_FILE_SIZE,
                                                runTimeout,
                                                maxOutputFileSize)
-        return timeout(["ssh"] + Ec2SSH._SSH_FLAGS +
+        ret = timeout(["ssh"] + Ec2SSH._SSH_FLAGS +
                        ["%s@%s" % (config.Config.EC2_USER_NAME, domain_name), runcmd], runTimeout * 2)
+        return ret
         # runTimeout * 2 is a temporary hack. The driver will handle the timout
 
     def copyOut(self, vm, destFile):
@@ -335,7 +336,7 @@ class Ec2SSH:
                 pass
 
         return timeout(["scp"] + Ec2SSH._SSH_FLAGS +
-                       ["%s@%s" % (config.Config.EC2_USER_NAME, domain_name), destFile],
+                       ["%s@%s:output" % (config.Config.EC2_USER_NAME, domain_name), destFile],
                        config.Config.COPYOUT_TIMEOUT)
 
     def destroyVM(self, vm):

--- a/vmms/ec2SSH.py
+++ b/vmms/ec2SSH.py
@@ -441,4 +441,4 @@ class Ec2SSH:
         """ getImages - Lists all images in TASHI_IMAGE_PATH that have the
         .img extension
         """
-        return ["test.img"]
+        return ["default.img"]

--- a/vmms/ec2SSH.py
+++ b/vmms/ec2SSH.py
@@ -299,11 +299,7 @@ class Ec2SSH:
             # If the call to ssh returns timeout (-1) or ssh error
             # (255), then success. Otherwise, keep trying until we run
             # out of time.
-<<<<<<< HEAD
             ret = timeout(["ssh"] + self.ssh_flags +
-=======
-            ret = timeout(["ssh"] + Ec2SSH._SSH_FLAGS +
->>>>>>> d82f287da1fc2d54d82f7bc620bab042add5a161
                           ["%s@%s" % (config.Config.EC2_USER_NAME, domain_name),
                            "(:)"], max_secs - elapsed_secs)
 
@@ -322,22 +318,14 @@ class Ec2SSH:
         domain_name = self.domainName(vm)
 
         # Create a fresh input directory
-<<<<<<< HEAD
         ret = subprocess.call(["ssh"] + self.ssh_flags +
-=======
-        ret = subprocess.call(["ssh"] + Ec2SSH._SSH_FLAGS +
->>>>>>> d82f287da1fc2d54d82f7bc620bab042add5a161
                               ["%s@%s" % (config.Config.EC2_USER_NAME, domain_name),
                                "(rm -rf autolab; mkdir autolab)"])
 
         # Copy the input files to the input directory
         for file in inputFiles:
             ret = timeout(["scp"] +
-<<<<<<< HEAD
                           self.ssh_flags +
-=======
-                          Ec2SSH._SSH_FLAGS +
->>>>>>> d82f287da1fc2d54d82f7bc620bab042add5a161
                           [file.localFile, "%s@%s:autolab/%s" %
                            (config.Config.EC2_USER_NAME, domain_name, file.destFile)],
                             config.Config.COPYIN_TIMEOUT)
@@ -359,14 +347,9 @@ class Ec2SSH:
                                                config.Config.VM_ULIMIT_FILE_SIZE,
                                                runTimeout,
                                                maxOutputFileSize)
-<<<<<<< HEAD
         ret = timeout(["ssh"] + self.ssh_flags +
                        ["%s@%s" % (config.Config.EC2_USER_NAME, domain_name), runcmd], runTimeout * 2)
         return ret
-=======
-        return timeout(["ssh"] + Ec2SSH._SSH_FLAGS +
-                       ["%s@%s" % (config.Config.EC2_USER_NAME, domain_name), runcmd], runTimeout * 2)
->>>>>>> d82f287da1fc2d54d82f7bc620bab042add5a161
         # runTimeout * 2 is a temporary hack. The driver will handle the timout
 
     def copyOut(self, vm, destFile):
@@ -407,11 +390,7 @@ class Ec2SSH:
                 # Error copying out the timing data (probably runJob failed)
                 pass
 
-<<<<<<< HEAD
         return timeout(["scp"] + self.ssh_flags +
-=======
-        return timeout(["scp"] + Ec2SSH._SSH_FLAGS +
->>>>>>> d82f287da1fc2d54d82f7bc620bab042add5a161
                        ["%s@%s:output" % (config.Config.EC2_USER_NAME, domain_name), destFile],
                        config.Config.COPYOUT_TIMEOUT)
 

--- a/vmms/ec2SSH.py
+++ b/vmms/ec2SSH.py
@@ -85,14 +85,18 @@ class Ec2SSH:
                   "-o", "StrictHostKeyChecking no",
                   "-o", "GSSAPIAuthentication no"]
 
-    def __init__(self):
+    def __init__(self, accessKeyId=None, accessKey=None):
         """ log - logger for the instance
         connection - EC2Connection object that stores the connection
         info to the EC2 network
         instance - Instance object that stores information about the
         VM created
         """
-        self.connection = ec2.connect_to_region(config.Config.EC2_REGION)
+        if accessKeyId:
+            self.connection = ec2.connect_to_region(config.Config.EC2_REGION,
+                    aws_access_key_id=accessKeyId, aws_secret_access_key=accessKey)
+        else:
+            self.connection = ec2.connect_to_region(config.Config.EC2_REGION)
         self.log = logging.getLogger("Ec2SSH")
 
     def instanceName(self, id, name):

--- a/worker.py
+++ b/worker.py
@@ -40,14 +40,17 @@ class Worker(threading.Thread):
     #
     # Worker helper functions
     #
-    def detachVM(self, return_vm=False, replace_vm=False):
+    def detachVM(self, return_vm=False, replace_vm=False, destory_vm=False):
         """ detachVM - Detach the VM from this worker. The options are
         to return it to the pool's free list (return_vm), destroy it
         (not return_vm), and if destroying it, whether to replace it
         or not in the pool (replace_vm). The worker must always call
         this function before returning.
         """
-        if return_vm:
+        # job-owned instance, simply destroy after job is completed
+        if self.job.accessKeyId:
+            self.vmms.safeDestroyVM(self.job.vm)
+        elif return_vm:
             self.preallocator.freeVM(self.job.vm)
         else:
             self.vmms.safeDestroyVM(self.job.vm)

--- a/worker.py
+++ b/worker.py
@@ -108,7 +108,7 @@ class Worker(threading.Thread):
         """
         f = open(filename, "a")
         f.write("Autograder [%s]: %s\n" % (datetime.now().ctime(), msg))
-        f.close
+        f.close()
 
     def catFiles(self, f1, f2):
         """ catFiles - cat f1 f2 > f2, where f1 is the Tango header
@@ -125,7 +125,7 @@ class Worker(threading.Thread):
                 shutil.copyfileobj(f2fd, wf)
         except OSError:
             pass
-        wf.close
+        wf.close()
         os.rename(tmpname, f2)
         os.remove(f1)
 

--- a/worker.py
+++ b/worker.py
@@ -40,7 +40,7 @@ class Worker(threading.Thread):
     #
     # Worker helper functions
     #
-    def detachVM(self, return_vm=False, replace_vm=False, destory_vm=False):
+    def detachVM(self, return_vm=False, replace_vm=False):
         """ detachVM - Detach the VM from this worker. The options are
         to return it to the pool's free list (return_vm), destroy it
         (not return_vm), and if destroying it, whether to replace it


### PR DESCRIPTION
Changes proposed in this PR:
-  Allow Autolab front-end to specify the AWS credentials that are used in auto-grading
-  Back-compatibility preserved (new features are effective only when accessKeyId and acceessKey is passed in)
-  change restful clients accordingly