### PR TITLE
Fix crash on missing job

### DIFF
--- a/jobManager.py
+++ b/jobManager.py
@@ -102,7 +102,10 @@ class JobManager:
                     ).start()
 
                 except Exception as err:
-                    self.jobQueue.makeDead(job.id, str(err))
+                    if job:
+                        self.jobQueue.makeDead(job.id, str(err))
+                    else:
+                        self.log.info("Missing job %d, error: %s" % (id, str(err)))
 
             # Sleep for a bit and then check again
             time.sleep(Config.DISPATCH_PERIOD)


### PR DESCRIPTION
Hi guys,

The jobManager was occasionally crashing on makeDead.

"'NoneType' object has no attribute 'id'" on the line including makeDead.

If the job is None, that must mean that getNextPendingJobReuse returned a job id that jobqueue.get couldn't get.

Anyways, this exception was happening in the except block so actually killed the jobManager. Added an if statement to avoid the crash. Would maybe be better to have an inner try block just to make the thing more resilient.

Doesn't address the core problem of why the job is missing, but fixes my problems for now.

Cheers!