### PR TITLE
Do not strip non-ascii chars from outputFile

### DIFF
--- a/worker.py
+++ b/worker.py
@@ -137,15 +137,13 @@ class Worker(threading.Thread):
             if job.notifyURL:
                 outputFileName = job.outputFile.split(
                     "/")[-1]  # get filename from path
-                fh = open(job.outputFile, 'rb')
-                files = {'file': unicode(fh.read(), errors='ignore')}
+                files = {'file': open(job.outputFile, 'rb')}
                 hdrs = {'Filename': outputFileName}
                 self.log.debug("Sending request to %s" % job.notifyURL)
                 response = requests.post(
                     job.notifyURL, files=files, headers=hdrs, verify=False)
                 self.log.info("Response from callback to %s:%s" %
                               (job.notifyURL, response.content))
-                fh.close()
         except Exception as e:
             self.log.debug("Error in notifyServer: %s" % str(e))
 


### PR DESCRIPTION
Currently, Tango calls `unicode(fh.read(), errors='ignore')` to read `outputFile` contents before sending them to the `notifyURL`. This has the side effect of stripping any non-ascii characters, which leads to unreadable text in most non-English languages.

Once Autolab is fixed (by merging autolab/Autolab#975) to support receiving unicode feedback messages, then there is no point in stripping non-ascii characters.

Then, we can just pass the file object, which is much simpler and is the way [recommended by the python-requests documentation](http://docs.python-requests.org/en/master/user/quickstart/#post-a-multipart-encoded-file) to send a file.