### PR TITLE
Use tornado streaming for uploads

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ redis==2.10.3
 requests==2.2.1
 rpyc==3.3.0
 wsgiref==0.1.2
-tornado==3.2
+tornado==4.1

--- a/restful-tango/tangoREST.py
+++ b/restful-tango/tangoREST.py
@@ -274,6 +274,7 @@ class TangoREST:
                     if self.checkFileExists(labPath, file, fileMD5):
                         self.log.info(
                             "File (%s, %s, %s) exists" % (key, courselab, file))
+                        os.unlink(tempfile)
                         return self.status.file_exists
                     absPath = "%s/%s" % (labPath, file)
                     os.rename(tempfile, absPath)


### PR DESCRIPTION
Instead of allowing tornado to buffer the entire upload in memory, use tornado.web.stream_request_body to write chunks to a temporary file. 

This seems to completely fix the tango super-slowdown on large files we've experienced with ML courses.