### PR TITLE
Fix regression during file upload

### DIFF
--- a/restful-tango/server.py
+++ b/restful-tango/server.py
@@ -83,7 +83,7 @@ class UploadHandler(tornado.web.RequestHandler):
     def post(self, key, courselab):
         """ post - Handles the post request to upload."""
         name = self.tempfile.name
-        self.tempfile.close
+        self.tempfile.close()
         return tangoREST.upload(
             key,
             courselab,


### PR DESCRIPTION
Regression caused by commit 05e4d0f375afccd35b85ebd5ef8b7f96000f6324. Files are
copied from a temp file to the final destination as the file has not been fully
uploaded and flushed. That yielded to grading corrupted or empty files.

Fixes #154 