### PR TITLE
Porting the autograder image to alpine linux

### DIFF
--- a/autodriver/Makefile
+++ b/autodriver/Makefile
@@ -6,7 +6,7 @@ OBJS = autodriver.o
 all: autodriver
 
 autodriver: $(OBJS)
-	$(CC) $(LDFLAGS) -o autodriver $(OBJS)
+	$(CC) -o autodriver $(OBJS) $(LDFLAGS)
 	sudo chown root autodriver
 	sudo chmod +s autodriver
 

--- a/autodriver/Makefile
+++ b/autodriver/Makefile
@@ -7,8 +7,6 @@ all: autodriver
 
 autodriver: $(OBJS)
 	$(CC) -o autodriver $(OBJS) $(LDFLAGS)
-	sudo chown root autodriver
-	sudo chmod +s autodriver
 
 autodriver.o: autodriver.c
 

--- a/autodriver/autodriver.c
+++ b/autodriver/autodriver.c
@@ -130,9 +130,16 @@ static int parse_user(char *name, struct passwd *user_info, char **buf) {
     long bufsize;
     int s;
 
-    if ((bufsize = sysconf(_SC_GETPW_R_SIZE_MAX)) < 0) {
-        ERROR_ERRNO("Unable to get buffer size");
-        exit(EXIT_OSERROR);
+    errno = 0;
+    bufsize = sysconf(_SC_GETPW_R_SIZE_MAX);
+    if (bufsize < 0) {
+        // POSIX doc: need to set bufsize if -1 returned and errno unchanged
+        if (bufsize == -1 && errno == 0) {
+            bufsize = 1024;
+        } else {
+            ERROR_ERRNO("Unable to get buffer size");
+            exit(EXIT_OSERROR);
+        }
     }
 
     if ((*buf = malloc(bufsize)) == NULL) {

--- a/autodriver/autodriver.c
+++ b/autodriver/autodriver.c
@@ -398,7 +398,7 @@ static void cleanup(void) {
     // We are currently in ~user.
     // (Note by @mpandya: the find binary is in /bin in RHEL but in /usr/bin
     // in Ubuntu)
-    char *find_args[] = {"find", "/usr/bin/find", ".", "/tmp", "/var/tmp", "-user", 
+    char *find_args[] = {"env", "find", ".", "/tmp", "/var/tmp", "-user",
         args.user_info.pw_name, "-delete", NULL};
     if (call_program("/usr/bin/env", find_args) != 0) {
         ERROR("Error deleting user's files");

--- a/vmms/Dockerfile_alpine
+++ b/vmms/Dockerfile_alpine
@@ -1,0 +1,19 @@
+FROM alpine:3.11
+
+WORKDIR /home
+RUN apk add bash make coreutils procps findutils gcc libc-dev argp-standalone && \
+    mkdir -p autodriver && \
+    cd autodriver && \
+    wget "https://raw.githubusercontent.com/wlnirvana/Tango/master/autodriver/autodriver.c" && \
+    wget "https://raw.githubusercontent.com/wlnirvana/Tango/master/autodriver/Makefile" && \
+    make clean && \
+    make LDFLAGS=-largp && \
+    cp autodriver /usr/bin/autodriver && \
+    chmod +s /usr/bin/autodriver && \
+    cd /home && \
+    adduser -D autolab && \
+    adduser -D autograde && \
+    mkdir output && \
+    chown autolab:autolab output && \
+    apk del argp-standalone && \
+    rm -rf autodriver


### PR DESCRIPTION
When getting suggested buffer size with`sysconf(_SC_GETPW_R_SIZE_MAX)` on some OSes (e.g. Alpine linux with musl,  FreeBSD, etc.), -1 is returned, causing autodriver to exit. This PR sets the buffer size to 1024 based on the [POSIX doc][1] 

[1]:https://pubs.opengroup.org/onlinepubs/9699919799.2008edition/functions/getpwnam.html#top