### PR TITLE
Dockerfile OS update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ pip-selfcheck.json
 
 # Mac OS X custom attribute files
 .DS_Store
+
+# IDEs
+.idea

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Start with empty ubuntu machine
-FROM ubuntu:15.04
+FROM ubuntu:18.04
 
 MAINTAINER Autolab Development Team "autolab-dev@andrew.cmu.edu"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,24 +16,27 @@ RUN mkdir -p volumes
 
 WORKDIR /opt
 
+# To avoid having a prompt on tzdata setup during installation
+ENV DEBIAN_FRONTEND=noninteractive 
+
 # Install dependancies
 RUN apt-get update && apt-get install -y \
 	nginx \
 	curl \
 	git \
-    vim \
-    supervisor \
-    python-pip \
-    python-dev \
-    build-essential \
-    tcl8.5 \
-    wget \
-    libgcrypt11-dev \
-    zlib1g-dev \
+	vim \
+	supervisor \
+	python-pip \
+	python-dev \
+	build-essential \
+	tcl8.5 \
+	wget \
+	libgcrypt11-dev \
+	zlib1g-dev \
 	apt-transport-https \
-    ca-certificates \
-    lxc \
-    iptables \
+	ca-certificates \
+	lxc \
+	iptables \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Changes Ubuntu version to 18.04 as 15.04 is long out of EOL.

The environment variable is added because tzdata has an interactive prompt for ease of usage by default but this stalls the Docker installation. The usage of the env var ensures that the interactive prompt is disabled.