### PR TITLE
Make volumes paths explicit to avoid assuming cwd

### DIFF
--- a/config.template.py
+++ b/config.template.py
@@ -40,6 +40,12 @@ class Config:
     # "tashiSSH", and "ec2SSH"
     VMMS_NAME = "localDocker"
 
+    # Update this to the 'volumes' directory of your Tango installation if
+    # Docker is being used.
+    # It must be an absolute path with trailing slash, i.e
+    # /opt/TangoService/Tango/volumes/
+    DOCKER_VOLUME_PATH = '/opt/TangoService/Tango/volumes'
+
     #####
     # Part 2: Constants that shouldn't need to change very often.
     #
@@ -73,9 +79,6 @@ class Config:
     BOOT2DOCKER_ENV_TIMEOUT = 5
     DOCKER_IMAGE_BUILD_TIMEOUT = 300
     DOCKER_RM_TIMEOUT = 5
-    # Must be absolute path with trailing slash
-    # Default value of '*'' points this path to /path/to/Tango/volumes/
-    DOCKER_VOLUME_PATH = '*'
     DOCKER_HOST_USER = ''
 
     # Maximum size for input files in bytes

--- a/config.template.py
+++ b/config.template.py
@@ -41,10 +41,10 @@ class Config:
     VMMS_NAME = "localDocker"
 
     # Update this to the 'volumes' directory of your Tango installation if
-    # Docker is being used.
+    # Docker is being used as the VMMs.
     # It must be an absolute path with trailing slash, i.e
     # /opt/TangoService/Tango/volumes/
-    DOCKER_VOLUME_PATH = '/opt/TangoService/Tango/volumes'
+    DOCKER_VOLUME_PATH = ""
 
     #####
     # Part 2: Constants that shouldn't need to change very often.

--- a/vmms/distDocker.py
+++ b/vmms/distDocker.py
@@ -105,8 +105,6 @@ class DistDocker:
 
     def getVolumePath(self, instanceName):
         volumePath = config.Config.DOCKER_VOLUME_PATH
-        if '*' in volumePath:
-            volumePath = os.getcwd() + '/' + 'volumes/'
         volumePath = volumePath + instanceName + '/'
         return volumePath
 

--- a/vmms/distDocker.py
+++ b/vmms/distDocker.py
@@ -105,7 +105,8 @@ class DistDocker:
 
     def getVolumePath(self, instanceName):
         volumePath = config.Config.DOCKER_VOLUME_PATH
-        volumePath = volumePath + instanceName + '/'
+        # Last empty string to cause trailing '/'
+        volumePath = os.path.join(volumePath, instanceName, "")
         return volumePath
 
     #

--- a/vmms/localDocker.py
+++ b/vmms/localDocker.py
@@ -86,9 +86,9 @@ class LocalDocker:
 
     def getVolumePath(self, instanceName):
         volumePath = config.Config.DOCKER_VOLUME_PATH
-        if '*' in volumePath:
-            volumePath = os.getcwd() + '/' + 'volumes/'
+        print("originally it would of been ", os.getcwd() + '/' + 'volumes/')
         volumePath = volumePath + instanceName + '/'
+        print("Now it is ", volumePath)
         return volumePath
 
     def domainName(self, vm):

--- a/vmms/localDocker.py
+++ b/vmms/localDocker.py
@@ -86,9 +86,8 @@ class LocalDocker:
 
     def getVolumePath(self, instanceName):
         volumePath = config.Config.DOCKER_VOLUME_PATH
-        print("originally it would of been ", os.getcwd() + '/' + 'volumes/')
-        volumePath = volumePath + instanceName + '/'
-        print("Now it is ", volumePath)
+        # Last empty string to cause trailing '/'
+        volumePath = os.path.join(volumePath, instanceName, "")
         return volumePath
 
     def domainName(self, vm):


### PR DESCRIPTION
In the Tango deployment instructions for Docker on Ubuntu 18.04, os.cwd() is unable to find the current directory of the Tango installation. I'm guessing most likely that the problem arose because of a difference in how supervisord or the OS determines the current working directory of a service. Previously, the cwd was probably inherited from where the supervisor daemon was started, but this implicit behavior is probably undefined behavior and we shouldn't be relying on it.

This PR forces the volume directory to be explicitly specified.
