### PR TITLE
Fix the encoding bug when reading the input file for Python3

### DIFF
--- a/restful-tango/tangoREST.py
+++ b/restful-tango/tangoREST.py
@@ -112,7 +112,7 @@ class TangoREST(object):
         for elem in os.listdir(directory):
             if elem == filename:
                 try:
-                    body = open("%s/%s" % (directory, elem)).read().encode('utf-8')
+                    body = open("%s/%s" % (directory, elem), "rb").read()
                     md5hash = hashlib.md5(body).hexdigest()
                     return md5hash == fileMD5
                 except IOError:


### PR DESCRIPTION
Tango will raise the error when the `autograde.tar`(uploaded from Autolab) has one or more binary file inside.

---

I use Tango as a java grader. However, once I pack some `.jar` into the `autograde.tar`, Autolab raise some upload errors.

And I found it is the bug occurred in Python3 when reading the file not in binary mode in the file-existence checking function.


For example, I put some binary files in `autograde` and remove them in `autograde1`
```
$ tar cf  autograde1.tar autograde1/
$ python3 -c "open('autograde1.tar').read()"

$ tar cf  autograde.tar autograde/         
$ python3 -c "open('autograde.tar').read()"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/usr/lib/python3.8/codecs.py", line 322, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xdd in position 12298: invalid continuation byte
```


Changes proposed in this PR:
-  Use `rb` to read input file.