### PR TITLE
Docker-compose setup Tango restful key fix

### DIFF
--- a/config.template.py
+++ b/config.template.py
@@ -55,7 +55,8 @@ class Config(object):
     #
 
     # Keys for Tango to authenticate client requests
-    KEYS = ["test"]
+    DEFAULT_KEY = "test"
+    KEYS = [os.getenv("DOCKER_TANGO_KEY", DEFAULT_KEY)]
 
     # Queue manager checks for new work every so many seconds
     DISPATCH_PERIOD = 0.2

--- a/config.template.py
+++ b/config.template.py
@@ -56,7 +56,7 @@ class Config(object):
 
     # Keys for Tango to authenticate client requests
     DEFAULT_KEY = "test"
-    KEYS = [os.getenv("DOCKER_TANGO_KEY", DEFAULT_KEY)]
+    KEYS = [os.getenv("RESTFUL_KEY", DEFAULT_KEY)]
 
     # Queue manager checks for new work every so many seconds
     DISPATCH_PERIOD = 0.2


### PR DESCRIPTION
The key to use for the docker-compose installation currently isn't being propagated to the config file, which this aims to fix. This results in Tango complaining that Autolab is using the wrong key, and therefore rejects all requests. 

This is meant to be reviewed together with https://github.com/autolab/docker/compare/tango-key-fix