### PR TITLE
Add a dockerfile allowing grading of Java and dotnet programs

### DIFF
--- a/vmms/Dockerfile_dotnet
+++ b/vmms/Dockerfile_dotnet
@@ -1,0 +1,36 @@
+FROM mcr.microsoft.com/dotnet/sdk:3.1
+MAINTAINER Vinay Venkat (@cool00geek)
+
+RUN apt-get update --fix-missing
+RUN apt-get install -y gcc
+RUN apt-get install -y make
+RUN apt-get install -y build-essential
+
+# Install autodriver
+WORKDIR /home
+RUN useradd autolab
+RUN useradd autograde
+RUN mkdir autolab autograde output
+RUN chown autolab:autolab autolab
+RUN chown autolab:autolab output
+RUN chown autograde:autograde autograde
+RUN apt-get install -y git
+RUN git clone https://github.com/autolab/Tango.git
+WORKDIR Tango/autodriver
+RUN sed -i "s/sudo //g" Makefile
+RUN make clean && make
+RUN cp autodriver /usr/bin/autodriver
+RUN chmod +s /usr/bin/autodriver
+
+# Clean up
+WORKDIR /home
+RUN apt-get remove -y git
+RUN apt-get -y autoremove
+RUN rm -rf Tango/
+
+# Set dotnet environment
+ENV DOTNET_CLI_HOME /tmp
+
+# Check installation
+RUN ls -l /home
+RUN which autodriver

--- a/vmms/Dockerfile_java
+++ b/vmms/Dockerfile_java
@@ -1,0 +1,33 @@
+FROM openjdk:11
+MAINTAINER Vinay Venkat (@cool00geek)
+
+RUN apt-get update --fix-missing
+RUN apt-get install -y gcc
+RUN apt-get install -y make
+RUN apt-get install -y build-essential
+
+# Install autodriver
+WORKDIR /home
+RUN useradd autolab
+RUN useradd autograde
+RUN mkdir autolab autograde output
+RUN chown autolab:autolab autolab
+RUN chown autolab:autolab output
+RUN chown autograde:autograde autograde
+RUN apt-get install -y git
+RUN git clone https://github.com/autolab/Tango.git
+WORKDIR Tango/autodriver
+RUN sed -i "s/sudo //g" Makefile
+RUN make clean && make
+RUN cp autodriver /usr/bin/autodriver
+RUN chmod +s /usr/bin/autodriver
+
+# Clean up
+WORKDIR /home
+RUN apt-get remove -y git
+RUN apt-get -y autoremove
+RUN rm -rf Tango/
+
+# Check installation
+RUN ls -l /home
+RUN which autodriver


### PR DESCRIPTION
Add a dockerfile for Java (OpenJDK 11) and .NET (.NET 3.1) so Tango can grade assignments in both Java and .NET.

To build the Java image:
`docker build -t autograding_java -f Dockerfile_java .` from the vmms/ directory

To build the .NET image: `docker build -t autograding_dotnet -f Dockerfile_dotnet .` from the vmms/ directory