### PR TITLE
Added Unassigned FIFO Queue to JobQueue

### DIFF
--- a/jobManager.py
+++ b/jobManager.py
@@ -68,7 +68,7 @@ class JobManager(object):
 
             if not job.accessKey and Config.REUSE_VMS:
                 vm = None
-                while (vm is None):
+                while vm is None:
                     vm = self.jobQueue.reuseVM(job)
                     # Sleep for a bit and then check again
                     time.sleep(Config.DISPATCH_PERIOD)

--- a/jobManager.py
+++ b/jobManager.py
@@ -70,6 +70,9 @@ class JobManager(object):
                 vm = None
                 while (vm is None):
                     vm = self.jobQueue.reuseVM(job)
+                    # Sleep for a bit and then check again
+                    time.sleep(Config.DISPATCH_PERIOD)
+
             try:
                 # Mark the job assigned
                 job.makeAssigned()
@@ -110,9 +113,6 @@ class JobManager(object):
 
             except Exception as err:
                 self.jobQueue.makeDead(job.id, str(err))
-
-            # Sleep for a bit and then check again
-            time.sleep(Config.DISPATCH_PERIOD)
 
 
 if __name__ == "__main__":

--- a/jobManager.py
+++ b/jobManager.py
@@ -68,11 +68,9 @@ class JobManager(object):
             job = self.jobQueue.getNextPendingJob()
 
             if not job.accessKey and Config.REUSE_VMS:
-                id, vm = self.jobQueue.getNextPendingJobReuse(job.id)
-                job = self.jobQueue.get(id)
-                if job == None:
-                    continue
-
+                vm = None
+                while (vm is None):
+                    vm = self.jobQueue.reuseVM(job)
             try:
                 # Mark the job assigned
                 job.makeAssigned()

--- a/jobQueue.py
+++ b/jobQueue.py
@@ -305,6 +305,9 @@ class JobQueue(object):
             # Remove the job from the live jobs dictionary 
             self.liveJobs.delete(id)
 
+            # Remove the job from the unassigned live jobs queue 
+            self.unassignedJobs.remove(int(id))
+
             job.appendTrace("%s|%s" % (datetime.utcnow().ctime(), reason))
         self.queueLock.release()
         self.log.debug("makeDead| Released lock to job queue.")

--- a/jobQueue.py
+++ b/jobQueue.py
@@ -34,6 +34,26 @@ from config import Config
 class JobQueue(object):
 
     def __init__(self, preallocator):
+        """
+        Here we maintain several data structures used to keep track of the 
+        jobs present for the autograder. 
+
+        Live jobs contains:
+        - jobs that are yet to be assigned and run
+        - jobs that are currently running
+
+        Dead jobs contains: 
+        - jobs that have been completed, or have been 'deleted' when in
+          the live jobs queue
+
+        This is a FIFO queue of jobs that are pending assignment. 
+        - We enforce the invariant that all jobs in this queue must be 
+          present in live jobs
+
+        queueLock protects all the internal data structure of JobQueue. This 
+        is needed since there are multiple worker threads and they might be 
+        using the makeUnassigned api.
+        """
         self.liveJobs = TangoDictionary("liveJobs")
         self.deadJobs = TangoDictionary("deadJobs")
         self.unassignedJobs = TangoQueue("unassignedLiveJobs")

--- a/jobQueue.py
+++ b/jobQueue.py
@@ -246,13 +246,14 @@ class JobQueue(object):
             job.retries += 1
             Config.job_retries += 1
 
+        self.log.info("unassignJob|Unassigning job %s" % str(job.id))
+        job.makeUnassigned()
+
         # Since the assumption is that the job is being retried, 
         # we simply add the job to the unassigned jobs queue without 
         # removing anything from it
         self.unassignedJobs.put(int(jobId))
 
-        self.log.info("unassignJob|Unassigning job %s" % str(job.id))
-        job.makeUnassigned()
         self.queueLock.release()
         self.log.debug("unassignJob| Released lock to job queue.")
 

--- a/jobQueue.py
+++ b/jobQueue.py
@@ -96,7 +96,7 @@ class JobQueue(object):
         self.liveJobs.set(job.id, job)
 
         # Add this to the unassigned job queue too 
-        self.unassignedJobs.put(job.id)
+        self.unassignedJobs.put(int(job.id))
 
         job.appendTrace("%s|Added job %s:%d to queue" %
                         (datetime.utcnow().ctime(), job.name, job.id))
@@ -204,7 +204,7 @@ class JobQueue(object):
         job = self.liveJobs.get(jobId)
 
         # Remove the current job from the queue
-        self.unassignedJobs.remove(jobId)
+        self.unassignedJobs.remove(int(jobId))
 
         self.log.debug("assignJob| Retrieved job.")
         self.log.info("assignJob|Assigning job ID: %s" % str(job.id))
@@ -229,7 +229,7 @@ class JobQueue(object):
         # Since the assumption is that the job is being retried, 
         # we simply add the job to the unassigned jobs queue without 
         # removing anything from it
-        self.unassignedJobs.put(jobId)
+        self.unassignedJobs.put(int(jobId))
 
         self.log.info("unassignJob|Unassigning job %s" % str(job.id))
         job.makeUnassigned()
@@ -255,7 +255,7 @@ class JobQueue(object):
             # Remove the job from the live jobs dictionary 
             self.liveJobs.delete(id)
             # Remove the job from the unassigned queue too
-            self.unassignedJobs.remove(id)
+            self.unassignedJobs.remove(int(id))
 
             job.appendTrace("%s|%s" % (datetime.utcnow().ctime(), reason))
         self.queueLock.release()

--- a/jobQueue.py
+++ b/jobQueue.py
@@ -46,6 +46,7 @@ class JobQueue(object):
         - jobs that have been completed, or have been 'deleted' when in
           the live jobs queue
 
+        Unassigned jobs: 
         This is a FIFO queue of jobs that are pending assignment. 
         - We enforce the invariant that all jobs in this queue must be 
           present in live jobs
@@ -92,6 +93,27 @@ class JobQueue(object):
         self.queueLock.release()
         self.log.debug("_getNextID|Released lock to job queue.")
         return id
+
+    def remove(self, id):	
+        """remove - Remove job from live queue	
+        """	
+        status = -1	
+        self.log.debug("remove|Acquiring lock to job queue.")	
+        self.queueLock.acquire()	
+        self.log.debug("remove|Acquired lock to job queue.")	
+        if id in self.liveJobs:	
+            self.liveJobs.delete(id)	
+            status = 0	
+        self.unassignedJobs.remove(int(id))
+
+        self.queueLock.release()	
+        self.log.debug("remove|Relased lock to job queue.")	
+
+        if status == 0:	
+            self.log.debug("Removed job %s from queue" % id)	
+        else:	
+            self.log.error("Job %s not found in queue" % id)	
+        return status	
 
     def add(self, job):
         """add - add job to live queue

--- a/jobQueue.py
+++ b/jobQueue.py
@@ -302,12 +302,13 @@ class JobQueue(object):
            blocking function and we will block till there is an available 
            job.
         """
+        # Blocks till the next item is added 
+        id = self.unassignedJobs.get()
+
         self.log.debug("_getNextPendingJob|Acquiring lock to job queue.")
         self.queueLock.acquire()
         self.log.debug("_getNextPendingJob|Acquired lock to job queue.")
 
-        # Blocks till the next item is added 
-        id = self.unassignedJobs.get()
         # Get the corresponding job
         job = self.liveJobs.get(id)
         if job is None:

--- a/jobQueue.py
+++ b/jobQueue.py
@@ -243,7 +243,7 @@ class JobQueue(object):
         self.log.debug("makeDead| Acquired lock to job queue.")
         status = -1
         if str(id) in self.liveJobs.keys():
-            self.log.info("makeDead| Found job ID: %d in the live queue" % (id))
+            self.log.info("makeDead| Found job ID: %s in the live queue" % (id))
             status = 0
             job = self.liveJobs.get(id)
             self.log.info("Terminated job %s:%d: %s" %

--- a/jobQueue.py
+++ b/jobQueue.py
@@ -93,7 +93,12 @@ class JobQueue(object):
         self.queueLock.acquire()
         self.log.debug("add| Acquired lock to job queue.")
 
+        # Adds the job to the live jobs dictionary
         self.liveJobs.set(job.id, job)
+
+        # Add this to the unassigned job queue too 
+        self.unassignedJobs.put(job.id)
+
         job.appendTrace("%s|Added job %s:%d to queue" %
                         (datetime.utcnow().ctime(), job.name, job.id))
 
@@ -266,6 +271,7 @@ class JobQueue(object):
         info = {}
         info['size'] = len(self.liveJobs.keys())
         info['size_deadjobs'] = len(self.deadJobs.keys())
+        info['size_unassignedjobs'] = self.unassignedJobs.qsize()
 
         return info
 

--- a/jobQueue.py
+++ b/jobQueue.py
@@ -274,8 +274,6 @@ class JobQueue(object):
             self.deadJobs.set(id, job)
             # Remove the job from the live jobs dictionary 
             self.liveJobs.delete(id)
-            # Remove the job from the unassigned queue too
-            self.unassignedJobs.remove(int(id))
 
             job.appendTrace("%s|%s" % (datetime.utcnow().ctime(), reason))
         self.queueLock.release()

--- a/tangoObjects.py
+++ b/tangoObjects.py
@@ -270,8 +270,10 @@ class TangoRemoteQueue(object):
         self.__db = getRedisConnection()
         self.__dict__.update(dict)
 
-    def remove(self, value):
-        return self.__db.lrem(self.key, 0, value)
+    def remove(self, item):
+        items = self.__db.lrange(self.key, 0, -1)
+        pickled_item = pickle.dumps(item)
+        return self.__db.lrem(self.key, 0, pickled_item)
 
     def _clean(self):
         self.__db.delete(self.key)

--- a/tangoObjects.py
+++ b/tangoObjects.py
@@ -9,7 +9,7 @@ standard_library.install_aliases()
 from builtins import str
 import redis
 import pickle
-import queue
+from queue import Queue
 from config import Config
 
 redisConnection = None
@@ -203,8 +203,18 @@ def TangoQueue(object_name):
     if Config.USE_REDIS:
         return TangoRemoteQueue(object_name)
     else:
-        return queue.Queue()
+        return ExtendedQueue()
 
+
+class ExtendedQueue(Queue):
+    """ Python Thread safe Queue with the remove and clean function added """
+
+    def remove(self, value):
+        with self.mutex:
+            self.queue.remove(value)
+    def _clean(self):
+        with self.mutex:
+            self.queue.clear()
 
 class TangoRemoteQueue(object):
 
@@ -238,8 +248,11 @@ class TangoRemoteQueue(object):
         else:
             item = self.__db.lpop(self.key)
 
-        # if item:
-        #     item = item[1]
+        if item is None:
+            return None
+
+        if block and item:
+            item = item[1]
 
         item = pickle.loads(item)
         return item
@@ -257,6 +270,11 @@ class TangoRemoteQueue(object):
         self.__db = getRedisConnection()
         self.__dict__.update(dict)
 
+    def remove(self, value):
+        return self.__db.lrem(self.key, 0, value)
+
+    def _clean(self):
+        self.__db.delete(self.key)
 
 # This is an abstract class that decides on
 # if we should initiate a TangoRemoteDictionary or TangoNativeDictionary

--- a/tests/testJobQueue.py
+++ b/tests/testJobQueue.py
@@ -97,9 +97,23 @@ class TestJobQueue(unittest.TestCase):
 
     def test_getNextPendingJob(self):
         self.jobQueue.assignJob(self.jobId2)
+        # job 2 should have been removed from unassigned queue
+        info = self.jobQueue.getInfo()
+        self.assertEqual(info['size_unassignedjobs'], 1)
+        self.jobQueue.assignJob(self.jobId1)
+        info = self.jobQueue.getInfo()
+        self.assertEqual(info['size_unassignedjobs'], 0)
         self.jobQueue.unassignJob(self.jobId1)
+        info = self.jobQueue.getInfo()
+        self.assertEqual(info['size_unassignedjobs'], 1)
         job = self.jobQueue.getNextPendingJob()
         self.assertMultiLineEqual(str(job.id), self.jobId1)
+
+    def test_getNextPendingJob2(self):
+        job = self.jobQueue.getNextPendingJob()
+        self.assertMultiLineEqual(str(job.id), self.jobId1)
+        job = self.jobQueue.getNextPendingJob()
+        self.assertMultiLineEqual(str(job.id), self.jobId2)
 
     def test_getNextPendingJobReuse(self):
         return False
@@ -121,17 +135,17 @@ class TestJobQueue(unittest.TestCase):
     def test_makeDead(self):
         info = self.jobQueue.getInfo()
         self.assertEqual(info['size_deadjobs'], 0)
+        self.assertEqual(info['size_unassignedjobs'], 2)
         self.jobQueue.makeDead(self.jobId1, "test")
         info = self.jobQueue.getInfo()
         self.assertEqual(info['size_deadjobs'], 1)
+        self.assertEqual(info['size_unassignedjobs'], 1)
 
     def test__getNextID(self):
-
         init_id = self.jobQueue.nextID
         for i in range(1, Config.MAX_JOBID + 100):
             id = self.jobQueue._getNextID()
             self.assertNotEqual(str(id), self.jobId1)
-
         self.jobQueue.nextID = init_id
 
 if __name__ == '__main__':

--- a/tests/testJobQueue.py
+++ b/tests/testJobQueue.py
@@ -91,8 +91,8 @@ class TestJobQueue(unittest.TestCase):
     def test_getNextPendingJob(self):
         self.jobQueue.assignJob(self.jobId2)
         self.jobQueue.unassignJob(self.jobId1)
-        exp_id = self.jobQueue.getNextPendingJob()
-        self.assertMultiLineEqual(exp_id, self.jobId1)
+        job = self.jobQueue.getNextPendingJob()
+        self.assertMultiLineEqual(str(job.id), self.jobId1)
 
     def test_getNextPendingJobReuse(self):
         return False

--- a/tests/testJobQueue.py
+++ b/tests/testJobQueue.py
@@ -66,6 +66,11 @@ class TestJobQueue(unittest.TestCase):
         info = self.jobQueue.getInfo()
         self.assertEqual(info['size'], 2)
 
+    def test_addTOUnassigned(self):
+        info = self.jobQueue.getInfo()
+
+        self.assertEqual(info['size_unassignedjobs'], 2)
+
     def test_addDead(self):
         return self.assertEqual(1, 1)
 

--- a/tests/testJobQueue.py
+++ b/tests/testJobQueue.py
@@ -115,8 +115,6 @@ class TestJobQueue(unittest.TestCase):
         job = self.jobQueue.getNextPendingJob()
         self.assertMultiLineEqual(str(job.id), self.jobId2)
 
-    def test_getNextPendingJobReuse(self):
-        return False
 
     def test_assignJob(self):
         self.jobQueue.assignJob(self.jobId1)

--- a/tests/testJobQueue.py
+++ b/tests/testJobQueue.py
@@ -66,9 +66,8 @@ class TestJobQueue(unittest.TestCase):
         info = self.jobQueue.getInfo()
         self.assertEqual(info['size'], 2)
 
-    def test_addTOUnassigned(self):
+    def test_addToUnassigned(self):
         info = self.jobQueue.getInfo()
-
         self.assertEqual(info['size_unassignedjobs'], 2)
 
     def test_addDead(self):
@@ -79,10 +78,13 @@ class TestJobQueue(unittest.TestCase):
         info = self.jobQueue.getInfo()
         self.assertEqual(info['size'], 1)
         self.assertEqual(info['size_deadjobs'], 1)
+        self.assertEqual(info['size_unassignedjobs'], 1)
 
         self.jobQueue.delJob(self.jobId1, 1)
         info = self.jobQueue.getInfo()
         self.assertEqual(info['size_deadjobs'], 0)
+        self.assertEqual(info['size'], 1)
+        self.assertEqual(info['size_unassignedjobs'], 1)
 
         return False
 

--- a/tests/testJobQueue.py
+++ b/tests/testJobQueue.py
@@ -69,15 +69,6 @@ class TestJobQueue(unittest.TestCase):
     def test_addDead(self):
         return self.assertEqual(1, 1)
 
-    def test_remove(self):
-        self.jobQueue.remove(self.jobId1)
-        info = self.jobQueue.getInfo()
-        self.assertEqual(info['size'], 1)
-
-        self.jobQueue.remove(self.jobId2)
-        info = self.jobQueue.getInfo()
-        self.assertEqual(info['size'], 0)
-
     def test_delJob(self):
         self.jobQueue.delJob(self.jobId1, 0)
         info = self.jobQueue.getInfo()

--- a/tests/testObjects.py
+++ b/tests/testObjects.py
@@ -4,11 +4,11 @@ from builtins import str
 import unittest
 import redis
 
-from tangoObjects import TangoDictionary, TangoJob
+from tangoObjects import TangoDictionary, TangoJob, TangoQueue
 from config import Config
 
 
-class TestObjects(unittest.TestCase):
+class TestDictionary(unittest.TestCase):
 
     def setUp(self):
         if Config.USE_REDIS:
@@ -55,6 +55,71 @@ class TestObjects(unittest.TestCase):
     def test_remoteDictionary(self):
         Config.USE_REDIS = True
         self.runDictionaryTests()
+
+
+class TestQueue(unittest.TestCase):
+    def setUp(self):
+        if Config.USE_REDIS:
+            __db = redis.StrictRedis(
+                Config.REDIS_HOSTNAME, Config.REDIS_PORT, db=0)
+            __db.flushall()
+        self.test_entries = [i for i in range(10)]
+    
+    def addAllToQueue(self):
+        # Add all items into the queue
+        for x in self.test_entries:
+            self.testQueue.put(x)
+            self.expectedSize += 1
+            self.assertEqual(self.testQueue.qsize(), self.expectedSize)
+
+    def runQueueTests(self):
+        self.testQueue = TangoQueue("self.testQueue")
+        self.expectedSize = 0
+        self.assertEqual(self.testQueue.qsize(), self.expectedSize)
+        self.assertTrue(self.testQueue.empty())
+
+        self.addAllToQueue()
+
+        # Test the blocking get
+        for x in self.test_entries:
+            item = self.testQueue.get()
+            self.expectedSize -= 1
+            self.assertEqual(self.testQueue.qsize(), self.expectedSize)
+            self.assertEqual(item, x)
+
+        self.addAllToQueue()
+
+        # Test the blocking get
+        for x in self.test_entries:
+            item = self.testQueue.get_nowait()
+            self.expectedSize -= 1
+            self.assertEqual(self.testQueue.qsize(), self.expectedSize)
+            self.assertEqual(item, x)
+
+        self.addAllToQueue()
+
+        # Remove all the even entries
+        for x in self.test_entries:
+            if (x % 2 == 0):
+                self.testQueue.remove(x)
+                self.expectedSize -= 1
+                self.assertEqual(self.testQueue.qsize(), self.expectedSize)
+
+        # Test that get only returns odd keys in order
+        for x in self.test_entries:
+            if (x % 2 == 1):
+                item = self.testQueue.get_nowait()
+                self.expectedSize -= 1
+                self.assertEqual(self.testQueue.qsize(), self.expectedSize)
+                self.assertEqual(item, x)
+
+    def test_nativeQueue(self):
+        Config.USE_REDIS = False
+        self.runQueueTests()
+
+    def test_remoteQueue(self):
+        Config.USE_REDIS = True
+        self.runQueueTests()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #142. Also improves efficiency + reduce representation gap of `jobQueue`.

Changes proposed in this PR:
- Added a `TangoQueue` for unassigned jobs. This keeps a FIFO queue of live jobs that have been added and not yet assigned to a worker or vm. Whenever we `getNextPendingJob`, we simply just have to pop off the FIFO queue. The current design only keeps a redis hash map to lookup job information. But a more straightforward representation of the `jobQueue` would be to actually have a FIFO queue too. This will make the runtime of many functions that are called repeatedly much faster.
Some implications of this new addition:
         - This helps to indirectly avoid the possible starvation problem as mentioned in the issue #142, since jobs are assigned or run based on their order in the FIFO queue, rather than arbitrarily based on their `jobID`s.
         - I've also used a blocking call to the redis list `lpop`. This means that `getNextPendingJob` will block until there is a next job available in the job queue. Previously, it seems like we have the `jobManager` spinning when there are no jobs, which might be less desirable.
        - To accommodate previous API methods in the `jobManager` like `delJob` etc., I have added methods to the `TangoQueue` object to remove items in the queue.
- I have also removed the `removeJob` method in the `jobQueue` which is currently unused and also do not seem to be useful. I also changed the `getNextPendingJobReuse` method so that it will be less expensive. Previously, it was looping through the hash table to find a job and initialiaze a pool of VMs for it. However, this can be simplified if we simply retrieve the job and pass it to a helper function to do this initialization.

### QA
- I've added tests for `TangoQueue` in the file `testObjects.py`. 
- I've also added more tests and assertions in the existing `testJobQueue.py` to test the addition of the unassigned queue whenever possible. 

To run these tests, use the command 
`python -m unittest <file>`
for e.g. 
`python -m unittest tests/testObjects.py`
