### PR TITLE
Fix bug with using 'in' in iteration context in TangoDict

### DIFF
--- a/preallocator.py
+++ b/preallocator.py
@@ -228,7 +228,7 @@ class Preallocator(object):
 
     def getAllPools(self):
         result = {}
-        for vmName in self.machines:
+        for vmName in self.machines.keys():
             result[vmName] = self.getPool(vmName)
         return result
 


### PR DESCRIPTION
Resolves a bug introduced in https://github.com/autolab/Tango/pull/187 that erroneously also changed an iteration instance to use the 'in' syntax, which is not supported as TangoDict does not implement `__iter__`. This bug was reported by 2 users on our community slack channel.

Testing plan:
1. Navigated to the Jobs page, and verified that there are no errors
2. Test submission of jobs and verify that the output was created in the `courselabs` directory (had issues with making callbacks to Autolab as I was testing locally without ssl, but Tango callbacks required ssl)