### PR TITLE
Fix buffer overflow bug in autodriver

### DIFF
--- a/autodriver/autodriver.c
+++ b/autodriver/autodriver.c
@@ -164,10 +164,12 @@ static int parse_user(char *name, struct passwd *user_info, char **buf) {
  * @return 0 on success, -1 on failure
  */
 static int dump_file(int fd, size_t bytes, off_t offset) {
-    char buffer[BUFSIZE];
+    char buffer[BUFSIZE + 1]; // keep the last byte as string terminator
     char *write_base;
     ssize_t nread, nwritten;
     size_t read_rem, write_rem;
+
+    memset(buffer, 0, BUFSIZE + 1);
 
     // Flush stdout so our writes here don't race with buffer flushes
     if (fflush(stdout) != 0) {


### PR DESCRIPTION
Fixes the issue where if the file is BUF_SIZE the buffer will not be properly null terminated, and also buffer allocated was too small to hold the null terminator.

This was inspired by https://github.com/autolab/Tango/commit/c1aa0ce4139b6e4e7aa119d18323ffde3a650221 but because of how much the code has diverged cherry picking is not possible. 