### PR TITLE
Catch exception if job already removed from unassignedJob queue

### DIFF
--- a/jobQueue.py
+++ b/jobQueue.py
@@ -209,10 +209,19 @@ class JobQueue(object):
         dead queue. If non-zero, remove the job from the dead queue
         and discard.
         """
+        status = -1
         if deadjob == 0:
+            try:
+                # Remove the job from the unassigned live jobs queue, if it
+                # is yet to be assigned.
+                self.unassignedJobs.remove(int(id))
+            except ValueError:
+                # Forbid deleting a job that has already been assigned
+                self.log.info("delJob | Job ID %s was already assigned" % (id))
+                return status
+
             return self.makeDead(id, "Requested by operator")
         else:
-            status = -1
             self.queueLock.acquire()
             self.log.debug("delJob| Acquired lock to job queue.")
             if id in self.deadJobs:
@@ -307,13 +316,6 @@ class JobQueue(object):
             self.deadJobs.set(id, job)
             # Remove the job from the live jobs dictionary
             self.liveJobs.delete(id)
-
-            try:
-                # Remove the job from the unassigned live jobs queue, if it
-                # is yet to be assigned.
-                self.unassignedJobs.remove(int(id))
-            except ValueError:
-                self.log.info("makeDead| Job ID %s was already assigned" % (id))
 
             job.appendTrace("%s|%s" % (datetime.utcnow().ctime(), reason))
         self.queueLock.release()

--- a/jobQueue.py
+++ b/jobQueue.py
@@ -308,8 +308,12 @@ class JobQueue(object):
             # Remove the job from the live jobs dictionary
             self.liveJobs.delete(id)
 
-            # Remove the job from the unassigned live jobs queue
-            self.unassignedJobs.remove(int(id))
+            try:
+                # Remove the job from the unassigned live jobs queue, if it
+                # is yet to be assigned.
+                self.unassignedJobs.remove(int(id))
+            except ValueError:
+                self.log.info("makeDead| Job ID %s was already assigned" % (id))
 
             job.appendTrace("%s|%s" % (datetime.utcnow().ctime(), reason))
         self.queueLock.release()


### PR DESCRIPTION
Addresses https://github.com/autolab/Tango/pull/196#issuecomment-789041313

There is a bug in jobQueue that causes it to raise an exception when attempting to remove a live job from the `unassignedJob` queue when it has already been removed previously/ 

This was because there was a wrong assumption that if a job is live, it must still be in the unassigned queue.

A live job can either be:
1. running (assigned to vm)
2. In the unassigned queue and waiting to be run on a vm.

The makeDead function is supposed to shift any live job to the dead job dictionary. So on line 312 we wrongly assumed that a live job has to be in the unassigned queue (it could be running) and hence will not be found in the unassigned queue.

This PR catches the ValueError that .remove may raise, and logs a message.