### PR TITLE
Allow tango-cli to use SSL

### DIFF
--- a/clients/tango-cli.py
+++ b/clients/tango-cli.py
@@ -465,6 +465,9 @@ if args.ssl:
     _tango_protocol = 'https'
     if args.port == 3000:
         args.port = 443
+    else:
+        print('SSL option ignored as custom port specified')
+
 
 try:
     response = requests.get('%s://%s:%d/' % (_tango_protocol, args.server, args.port))

--- a/clients/tango-cli.py
+++ b/clients/tango-cli.py
@@ -28,9 +28,11 @@ sys.path.append('/usr/lib/python2.7/site-packages/')
 #
 parser = argparse.ArgumentParser(description='')
 parser.add_argument('-s', '--server', default='localhost',
-                    help='Tango server endpoint (default = http://localhost)')
+                    help='Tango server endpoint (default = localhost)')
 parser.add_argument('-P', '--port', default=3000, type=int,
                     help='Tango server port number (default = 3000)')
+parser.add_argument('-S', '--ssl', default=False, action='store_true',
+                    help='Use ssl to communicate with tango (and change port to 443)')
 parser.add_argument('-k', '--key',
                     help='Key of client')
 parser.add_argument('-l', '--courselab',
@@ -137,6 +139,8 @@ def checkDeadjobs():
         return -1
     return 0
 
+_tango_protocol='http'
+
 # open
 
 
@@ -147,8 +151,8 @@ def tango_open():
             raise Exception("Invalid usage: [open] " + open_help)
 
         response = requests.get(
-            'http://%s:%d/open/%s/%s/' %
-            (args.server, args.port, args.key, args.courselab))
+            '%s://%s:%d/open/%s/%s/' %
+            (_tango_protocol, args.server, args.port, args.key, args.courselab))
         print("Sent request to %s:%d/open/%s/%s/" %
               (args.server, args.port, args.key, args.courselab))
         print(response.text)
@@ -174,8 +178,9 @@ def tango_upload():
         header = {'Filename': filename}
 
         response = requests.post(
-            'http://%s:%d/upload/%s/%s/' %
-            (args.server,
+            '%s://%s:%d/upload/%s/%s/' %
+            (_tango_protocol,
+             args.server,
              args.port,
              args.key,
              args.courselab),
@@ -216,8 +221,9 @@ def tango_addJob():
         requestObj['accessKey'] = args.accessKey
 
         response = requests.post(
-            'http://%s:%d/addJob/%s/%s/' %
-            (args.server,
+            '%s://%s:%d/addJob/%s/%s/' %
+            (_tango_protocol,
+             args.server,
              args.port,
              args.key,
              args.courselab),
@@ -248,8 +254,9 @@ def tango_poll():
             raise Exception("Invalid usage: [poll] " + poll_help)
 
         response = requests.get(
-            'http://%s:%d/poll/%s/%s/%s/' %
-            (args.server,
+            '%s://%s:%d/poll/%s/%s/%s/' %
+            (_tango_protocol,
+             args.server,
              args.port,
              args.key,
              args.courselab,
@@ -287,7 +294,7 @@ def tango_info():
             raise Exception("Invalid usage: [info] " + info_help)
 
         response = requests.get(
-            'http://%s:%d/info/%s/' % (args.server, args.port, args.key))
+            '%s://%s:%d/info/%s/' % (_tango_protocol, args.server, args.port, args.key))
         print("Sent request to %s:%d/info/%s/" %
               (args.server, args.port, args.key))
         print(response.text)
@@ -308,8 +315,8 @@ def tango_jobs():
             raise Exception("Invalid usage: [jobs] " + jobs_help)
 
         response = requests.get(
-            'http://%s:%d/jobs/%s/%d/' %
-            (args.server, args.port, args.key, args.deadJobs))
+            '%s://%s:%d/jobs/%s/%d/' %
+            (_tango_protocol, args.server, args.port, args.key, args.deadJobs))
         print("Sent request to %s:%d/jobs/%s/%d/" %
               (args.server, args.port, args.key, args.deadJobs))
         print(response.text)
@@ -329,8 +336,8 @@ def tango_pool():
         if res != 0:
             raise Exception("Invalid usage: [pool] " + pool_help)
 
-        response = requests.get('http://%s:%d/pool/%s/%s/' %
-                                (args.server, args.port, args.key, args.image))
+        response = requests.get('%s://%s:%d/pool/%s/%s/' %
+                                (_tango_protocol, args.server, args.port, args.key, args.image))
         print("Sent request to %s:%d/pool/%s/%s/" %
               (args.server, args.port, args.key, args.image))
         print(response.text)
@@ -356,8 +363,9 @@ def tango_prealloc():
         vmObj['memory'] = args.memory
 
         response = requests.post(
-            'http://%s:%d/prealloc/%s/%s/%s/' %
-            (args.server,
+            '%s://%s:%d/prealloc/%s/%s/%s/' %
+            (_tango_protocol,
+             args.server,
              args.port,
              args.key,
              args.image,
@@ -453,8 +461,14 @@ if (not args.open and not args.upload and not args.addJob
     parser.print_help()
     sys.exit(0)
 
+if args.ssl:
+    _tango_protocol = 'https'
+    if args.port == 3000:
+        args.port = 443
+
 try:
-    response = requests.get('http://%s:%d/' % (args.server, args.port))
+    response = requests.get('%s://%s:%d/' % (_tango_protocol, args.server, args.port))
+    response.raise_for_status()
 except BaseException:
     print('Tango not reachable on %s:%d!\n' % (args.server, args.port))
     sys.exit(0)


### PR DESCRIPTION
Give tango-cli.py a switch to enable SSL communication with tango

Changes proposed in this PR:
- Make the "protocol" (http) in tango urls passed to requests.get a variable instead of a constant in all the urls
- Add a switch -S (--ssl) to switch the protocol to https. The switch also changes the default port from 3000 to 443