### PR TITLE
Stop using the python-future module

### DIFF
--- a/clients/tango-cli.py
+++ b/clients/tango-cli.py
@@ -4,7 +4,6 @@
 # tango-cli.py - Command line client for the RESTful Tango.
 #
 
-from __future__ import print_function
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -13,11 +12,6 @@ import requests
 import argparse
 import sys
 import os
-from builtins import str
-from builtins import map
-from builtins import range
-from future import standard_library
-standard_library.install_aliases()
 
 sys.path.append('/usr/lib/python2.7/site-packages/')
 

--- a/config.template.py
+++ b/config.template.py
@@ -2,7 +2,6 @@
 # config.py - Global configuration constants and runtime info
 #
 
-from builtins import object
 import logging
 import time
 

--- a/jobManager.py
+++ b/jobManager.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 #
 # JobManager - Thread that assigns jobs to worker threads
 #
@@ -17,10 +15,7 @@ import time
 import logging
 import threading
 
-from builtins import str
-from builtins import object
 from datetime import datetime
-from future import standard_library
 
 import tango  # Written this way to avoid circular imports
 from config import Config
@@ -28,9 +23,6 @@ from tangoObjects import TangoQueue
 from worker import Worker
 from preallocator import Preallocator
 from jobQueue import JobQueue
-
-standard_library.install_aliases()
-
 
 class JobManager(object):
 

--- a/jobQueue.py
+++ b/jobQueue.py
@@ -7,9 +7,6 @@
 # JobManager: Class that creates a thread object that looks for new
 # work on the job queue and assigns it to workers.
 #
-from builtins import range
-from builtins import object
-from builtins import str
 import threading
 import logging
 import time

--- a/preallocator.py
+++ b/preallocator.py
@@ -1,8 +1,6 @@
 #
 # preallocator.py - maintains a pool of active virtual machines
 #
-from builtins import object
-from builtins import range
 import threading
 import logging
 import time

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,3 @@ redis==3.4.1
 requests==2.23.0
 rpyc==4.1.4
 tornado==4.5.3
-future==0.18.2

--- a/restful_tango/server.py
+++ b/restful_tango/server.py
@@ -12,10 +12,7 @@ import tornado.web
 from functools import partial, wraps
 from concurrent.futures import ThreadPoolExecutor
 from tempfile import NamedTemporaryFile
-from future import standard_library
 from tangoREST import TangoREST
-
-standard_library.install_aliases()
 
 currentdir = os.path.dirname(
     os.path.abspath(inspect.getfile(inspect.currentframe())))

--- a/restful_tango/tangoREST.py
+++ b/restful_tango/tangoREST.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 # tangoREST.py
 #
 # Implements open, upload, addJob, and poll to be used for the RESTful
@@ -11,9 +10,6 @@ import inspect
 import hashlib
 import json
 import logging
-
-from builtins import object
-from builtins import str
 
 currentdir = os.path.dirname(
     os.path.abspath(inspect.getfile(inspect.currentframe())))

--- a/tango.py
+++ b/tango.py
@@ -41,8 +41,6 @@ import stat
 import re
 import os
 
-from builtins import object
-from builtins import str
 from datetime import datetime
 
 from jobManager import JobManager

--- a/tangoObjects.py
+++ b/tangoObjects.py
@@ -6,11 +6,6 @@ from config import Config
 from queue import Queue
 import pickle
 import redis
-from builtins import str
-from builtins import range
-from builtins import object
-from future import standard_library
-standard_library.install_aliases()
 
 redisConnection = None
 

--- a/tests/testJobQueue.py
+++ b/tests/testJobQueue.py
@@ -1,6 +1,3 @@
-from __future__ import print_function
-from builtins import range
-from builtins import str
 import unittest
 import redis
 

--- a/tests/testObjects.py
+++ b/tests/testObjects.py
@@ -1,6 +1,3 @@
-from __future__ import print_function
-from builtins import range
-from builtins import str
 import unittest
 import redis
 

--- a/tests/validate.py
+++ b/tests/validate.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 #
 # Recursively validates all python files with pyflakes that were modified
 # since the last validation, and provides basic stats. Ignores hidden

--- a/vmms/distDocker.py
+++ b/vmms/distDocker.py
@@ -8,8 +8,6 @@
 # `domain_name` attribtue of TangoMachine.
 #
 
-from builtins import object
-from builtins import str
 import random
 import subprocess
 import re

--- a/vmms/ec2SSH.py
+++ b/vmms/ec2SSH.py
@@ -10,8 +10,6 @@
 #
 # TODO: this currently probably does not work on Python 3 yet
 
-from builtins import object
-from builtins import str
 import subprocess
 import os
 import re

--- a/vmms/localDocker.py
+++ b/vmms/localDocker.py
@@ -2,8 +2,6 @@
 # localDocker.py - Implements the Tango VMMS interface to run Tango jobs in
 #                docker containers. In this context, VMs are docker containers.
 #
-from builtins import object
-from builtins import str
 import random
 import subprocess
 import re

--- a/vmms/tashiSSH.py
+++ b/vmms/tashiSSH.py
@@ -9,8 +9,6 @@
 #   tashiCallError - raised by tashiCall() function
 #
 # TODO: this currently probably does not work on Python 3 yet
-from builtins import object
-from builtins import str
 import random
 import subprocess
 import os

--- a/worker.py
+++ b/worker.py
@@ -1,7 +1,6 @@
 #
 # worker.py - Thread that shepherds a job through it execution sequence
 #
-from builtins import str
 import threading
 import time
 import logging


### PR DESCRIPTION
Since this branch is now python3 only, the future module is not needed

Changes proposed in this PR:
-  Remove from __future__ import print_function
-  remove all imports of future and builtins
-  remove future from requirements.txt

python-future only has effects on python2. Since this branch is now supposedly python3 only, it should not be needed.
Also note that the previous code in tango-cli.py would not have worked on python2, because new style urllib imports were used before `standard_library.install_aliases()` was called