### PR TITLE
Revert warning on custom port with SSL option

### DIFF
--- a/clients/tango-cli.py
+++ b/clients/tango-cli.py
@@ -459,8 +459,6 @@ if args.ssl:
     _tango_protocol = 'https'
     if args.port == 3000:
         args.port = 443
-    else:
-        print('SSL option ignored as custom port specified')
 
 
 try:


### PR DESCRIPTION
Removes the warning when using SSL but also specifying SSL port, as it can be part of a legitimate workflow

https://github.com/autolab/Tango/pull/208#issuecomment-805878811