### PR TITLE
Change path to Python in Tango CLI

### DIFF
--- a/clients/tango-cli.py
+++ b/clients/tango-cli.py
@@ -1,4 +1,4 @@
-#!/usr/local/bin/python
+#!/usr/bin/env python3
 #
 #
 # tango-cli.py - Command line client for the RESTful Tango.


### PR DESCRIPTION
Changes the path to python3 in [clients/tango-cli.py](https://github.com/autolab/Tango/blob/49b1cf7784dd0d3e6fa816d98f8a0147b3d18e6a/clients/tango-cli.py) to be more portable in response to [this issue](https://github.com/autolab/Tango/issues/214).