### PR TITLE
fix: catch the network error in docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ RUN apt-get update && apt-get install -y \
 WORKDIR /opt/TangoService/Tango/
 
 # Install Docker from Docker Inc. repositories.
-RUN curl -sSL https://get.docker.com/ | sh
+RUN curl -sSL https://get.docker.com/ -o get_docker.sh && sh get_docker.sh
 
 # Install the magic wrapper.
 ADD ./wrapdocker /usr/local/bin/wrapdocker


### PR DESCRIPTION
Fixes the issue where if a network error occurs, the docker build process will not be terminated properly. By default, pipeline (`curl -sSL https://get.docker.com/ | sh`) doesn't produce a failure return code when the last command (`sh` here) returns zero, even if `curl` returns non-zero exit status.


