### PR TITLE
Allow failed posting of autograding results in Tango to be retried

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ boto==2.49.0 # used only by ec2SSH.py
 plumbum==1.6.9
 pyflakes==2.1.1
 redis==3.4.1
-requests==2.23.0
+requests==2.26.0
 rpyc==4.1.4
 tornado==4.5.3


### PR DESCRIPTION
This is based on a customized fix from Chaskiel. See https://github.com/cg2v/Tango/commit/885b9649a1021be9c57748c3a49ff771a8a2c04b.

@cg2v Thanks for suggesting the change! Let us know if you think it's ok for us to adopt it. We will also do further testing to make sure Tango functions normally before we merge it in.