### PR TITLE
Remove duplicated options

### DIFF
--- a/clients/tango-cli.py
+++ b/clients/tango-cli.py
@@ -62,40 +62,6 @@ prealloc_help = "Create a pool of instances spawned from a specific image. Must 
 parser.add_argument("--prealloc", action="store_true", help=prealloc_help)
 
 parser.add_argument("--runJob", help="Run a job from a specific directory")
-parser.add_argument(
-    "-s",
-    "--server",
-    default="localhost",
-    help="Tango server endpoint (default = http://localhost)",
-)
-parser.add_argument(
-    "-P",
-    "--port",
-    default=3000,
-    type=int,
-    help="Tango server port number (default = 3000)",
-)
-parser.add_argument("-k", "--key", help="Key of client")
-parser.add_argument("-l", "--courselab", help="Lab of client")
-
-open_help = "Opens directory for lab. Creates new one if it does not exist. Must specify key with -k and courselab with -l."
-parser.add_argument("-o", "--open", action="store_true", help=open_help)
-upload_help = "Uploads a file. Must specify key with -k, courselab with -l, and filename with --filename."
-parser.add_argument("-u", "--upload", action="store_true", help=upload_help)
-addJob_help = "Submit a job. Must specify key with -k, courselab with -l, and input files with --infiles. Modify defaults with --image (autograding_image), --outputFile (result.out), --jobname (test_job), --maxsize(0), --timeout (0)."
-parser.add_argument("-a", "--addJob", action="store_true", help=addJob_help)
-poll_help = "Poll a given output file. Must specify key with -k, courselab with -l. Modify defaults with --outputFile (result.out)."
-parser.add_argument("-p", "--poll", action="store_true", help=poll_help)
-info_help = "Obtain basic stats about the service such as uptime, number of jobs, number of threads etc. Must specify key with -k."
-parser.add_argument("-i", "--info", action="store_true", help=info_help)
-jobs_help = "Obtain information of live jobs (deadJobs == 0) or dead jobs (deadJobs == 1). Must specify key with -k. Modify defaults with --deadJobs (0)."
-parser.add_argument("-j", "--jobs", action="store_true", help=jobs_help)
-pool_help = "Obtain information about a pool of VMs spawned from a specific image. Must specify key with -k. Modify defaults with --image (autograding_image)."
-parser.add_argument("--pool", action="store_true", help=pool_help)
-prealloc_help = "Create a pool of instances spawned from a specific image. Must specify key with -k. Modify defaults with --image (autograding_image), --num (2), --vmms (localDocker), --cores (1), and --memory (512)."
-parser.add_argument("--prealloc", action="store_true", help=prealloc_help)
-
-parser.add_argument("--runJob", help="Run a job from a specific directory")
 parser.add_argument("--numJobs", type=int, default=1, help="Number of jobs to run")
 
 parser.add_argument(


### PR DESCRIPTION
Remove duplicated options that were added in #211 (the original lines are L24-62). `clients/tango-cli.py` now runs as expected.

Fixes #213.