### PR TITLE
Bump black version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,6 +15,6 @@ repos:
     -   id: check-toml
     -   id: sort-simple-yaml
 -   repo: https://github.com/psf/black
-    rev: 22.1.0
+    rev: 22.3.0
     hooks:
     -   id: black


### PR DESCRIPTION
Currently, the CI is failing due to `ImportError: cannot import name '_unicodefun' from 'click' (/home/runner/.cache/pre-commit/repoqlbiuu9o/py_env-python3.8/lib/python3.8/site-packages/click/__init__.py)`.

Resolving this by bumping Black to v22.3.0 as per https://stackoverflow.com/questions/71673404/importerror-cannot-import-name-unicodefun-from-click.
