### PR TITLE
Remove unneeded python requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,7 @@
 backports.ssl-match-hostname==3.7.0.1
 boto==2.49.0 # used only by ec2SSH.py
-plumbum==1.6.9
 pyflakes==2.1.1
 redis==3.4.1
 requests==2.26.0
-rpyc==4.1.4
+# needed for tashi, rpyc==4.1.4
 tornado==4.5.3


### PR DESCRIPTION
Address https://github.com/autolab/Tango/issues/210

Changes proposed in this PR:
- Removes plumbum
- Comments out rpyc needed only for Tashi

Tested by:
- Removing plumbum and rpyc from local python environment
- Doing a pip install of requirements
- Running up Tango with localdocker
- submitting a job
