### PR TITLE
Remove interactive flag from exec

### DIFF
--- a/vmms/distDocker.py
+++ b/vmms/distDocker.py
@@ -497,7 +497,7 @@ class DistDocker(object):
                 self.log.debug("Lost persistent SSH connection")
                 return ret
 
-        cmd = "(docker exec -it %s head -c %s autograde/output.log)" % (
+        cmd = "(docker exec %s head -c %s autograde/output.log)" % (
             instanceName,
             config.Config.MAX_OUTPUT_FILE_SIZE,
         )

--- a/vmms/localDocker.py
+++ b/vmms/localDocker.py
@@ -271,11 +271,15 @@ class LocalDocker(object):
         """
 
         instanceName = self.instanceName(vm.id, vm.image)
-        cmd = "docker exec -it %s head -c %s autograde/output.log" % (
+        cmd = "docker exec %s head -c %s autograde/output.log" % (
             instanceName,
             config.Config.MAX_OUTPUT_FILE_SIZE,
         )
-        output = subprocess.check_output(
-            cmd, stderr=subprocess.STDOUT, shell=True
-        ).decode("utf-8")
+        try:
+            output = subprocess.check_output(
+                cmd, stderr=subprocess.STDOUT, shell=True
+            ).decode("utf-8")
+        except subprocess.CalledProcessError as e:
+            output = str(e)
+
         return output

--- a/vmms/localDocker.py
+++ b/vmms/localDocker.py
@@ -275,11 +275,8 @@ class LocalDocker(object):
             instanceName,
             config.Config.MAX_OUTPUT_FILE_SIZE,
         )
-        try:
-            output = subprocess.check_output(
-                cmd, stderr=subprocess.STDOUT, shell=True
-            ).decode("utf-8")
-        except subprocess.CalledProcessError as e:
-            output = str(e)
+        output = subprocess.check_output(
+            cmd, stderr=subprocess.STDOUT, shell=True
+        ).decode("utf-8")
 
         return output


### PR DESCRIPTION
Fixes the issue where getPartialOutput does not work in Autolab Docker. 

Achieves it by removing the `-it` interactive flag that is meant for an interactive command, which throws an error when run in python in Docker.

**How to test**
Spin up Autolab Docker, do an autograding of hello.c with this content

```
/* Solution for the Hello Lab */
#include <stdio.h>
#include <stdlib.h>
#include <unistd.h>

int main()
{
    for (int i = 0; i < 5; i++)
    {
        /* code */

        printf("Hello, world\n");
        sleep(10);
        fflush(stdout);
    }
    return 0; /* important to return zero here */
}
```
Partial output should work (as long as the error of not appearing on the queue does not come up). Without this PR, it will always not work.