### PR TITLE
[WIP] Hotfix for job-queue

### DIFF
--- a/jobManager.py
+++ b/jobManager.py
@@ -73,8 +73,7 @@ class JobManager(object):
                     time.sleep(Config.DISPATCH_PERIOD)
 
             try:
-                # Mark the job assigned
-                job.makeAssigned()
+
                 # if the job has specified an account
                 # create an VM on the account and run on that instance
                 if job.accessKeyId:
@@ -108,7 +107,8 @@ class JobManager(object):
                     "%s|Dispatched job %s:%d [try %d]"
                     % (datetime.utcnow().ctime(), job.name, job.id, job.retries)
                 )
-
+                # Mark the job assigned
+                self.jobQueue.assignJob(job.id, preVM)
                 Worker(job, vmms, self.jobQueue, self.preallocator, preVM).start()
 
             except Exception as err:

--- a/jobQueue.py
+++ b/jobQueue.py
@@ -246,7 +246,7 @@ class JobQueue(object):
         self.log.debug("get| Released lock to job queue.")
         return job
 
-    def assignJob(self, jobId, vm = None):
+    def assignJob(self, jobId, vm=None):
         """assignJob - marks a job to be assigned"""
         self.queueLock.acquire()
         self.log.debug("assignJob| Acquired lock to job queue.")

--- a/jobQueue.py
+++ b/jobQueue.py
@@ -264,6 +264,7 @@ class JobQueue(object):
         self.log.debug("assignJob| Releasing lock to job queue.")
         self.queueLock.release()
         self.log.debug("assignJob| Released lock to job queue.")
+        #return job
 
     def unassignJob(self, jobId):
         """unassignJob - marks a job to be unassigned
@@ -307,11 +308,14 @@ class JobQueue(object):
             status = 0
             job = self.liveJobs.get(id)
             self.log.info("Terminated job %s:%s: %s" % (job.name, job.id, reason))
-
             # Add the job to the dead jobs dictionary
             self.deadJobs.set(id, job)
             # Remove the job from the live jobs dictionary
             self.liveJobs.delete(id)
+
+            #unassign, remove from unassigned jobs queue
+            job.makeUnassigned()
+            self.unassignedJobs.remove(int(id))
 
             job.appendTrace("%s|%s" % (datetime.utcnow().ctime(), reason))
         self.queueLock.release()

--- a/jobQueue.py
+++ b/jobQueue.py
@@ -259,6 +259,7 @@ class JobQueue(object):
         self.log.debug("assignJob| Retrieved job.")
         self.log.info("assignJob|Assigning job ID: %s" % str(job.id))
         job.makeAssigned()
+        job.makeVM()
 
         self.log.debug("assignJob| Releasing lock to job queue.")
         self.queueLock.release()

--- a/jobQueue.py
+++ b/jobQueue.py
@@ -246,7 +246,7 @@ class JobQueue(object):
         self.log.debug("get| Released lock to job queue.")
         return job
 
-    def assignJob(self, jobId, vm):
+    def assignJob(self, jobId, vm = None):
         """assignJob - marks a job to be assigned"""
         self.queueLock.acquire()
         self.log.debug("assignJob| Acquired lock to job queue.")

--- a/jobQueue.py
+++ b/jobQueue.py
@@ -246,7 +246,7 @@ class JobQueue(object):
         self.log.debug("get| Released lock to job queue.")
         return job
 
-    def assignJob(self, jobId):
+    def assignJob(self, jobId, vm):
         """assignJob - marks a job to be assigned"""
         self.queueLock.acquire()
         self.log.debug("assignJob| Acquired lock to job queue.")
@@ -259,7 +259,7 @@ class JobQueue(object):
         self.log.debug("assignJob| Retrieved job.")
         self.log.info("assignJob|Assigning job ID: %s" % str(job.id))
         job.makeAssigned()
-        job.makeVM()
+        job.makeVM(vm)
 
         self.log.debug("assignJob| Releasing lock to job queue.")
         self.queueLock.release()

--- a/jobQueue.py
+++ b/jobQueue.py
@@ -264,7 +264,7 @@ class JobQueue(object):
         self.log.debug("assignJob| Releasing lock to job queue.")
         self.queueLock.release()
         self.log.debug("assignJob| Released lock to job queue.")
-        #return job
+        # return job
 
     def unassignJob(self, jobId):
         """unassignJob - marks a job to be unassigned
@@ -313,7 +313,7 @@ class JobQueue(object):
             # Remove the job from the live jobs dictionary
             self.liveJobs.delete(id)
 
-            #unassign, remove from unassigned jobs queue
+            # unassign, remove from unassigned jobs queue
             job.makeUnassigned()
             self.unassignedJobs.remove(int(id))
 

--- a/tango.py
+++ b/tango.py
@@ -91,6 +91,8 @@ class TangoServer(object):
         self.start_time = time.time()
         self.log = logging.getLogger("TangoServer")
         self.log.info("Starting Tango server")
+        if Config.USE_REDIS:
+            self.log.info("BRUHRUWEHUASERH")
 
     def addJob(self, job):
         """addJob - Add a job to the job queue"""
@@ -218,6 +220,10 @@ class TangoServer(object):
             vm = jobInfo.vm
 
             if not jobInfo.assigned or vm is None:
+                self.log.info(
+                        "job %s %d is assigned ?: %d %s]"
+                        % (jobInfo.name, jobInfo.id, jobInfo.assigned)
+                )
                 raise Exception("Job %s is not running yet" % jobid)
 
             vmms = self.preallocator.vmms[Config.VMMS_NAME]

--- a/tango.py
+++ b/tango.py
@@ -219,14 +219,19 @@ class TangoServer(object):
 
             if not jobInfo.assigned or vm is None:
                 self.log.info(
-                        "job %s %d is assigned %d, job dict: %s ID: %s]"
-                        % (jobInfo.name, jobInfo.id, jobInfo.assigned,
-                          str(jobInfo.__dict__), jobInfo.vm.id)
+                    "job %s %d is assigned %d, job dict: %s ID: %s]"
+                    % (
+                        jobInfo.name,
+                        jobInfo.id,
+                        jobInfo.assigned,
+                        str(jobInfo.__dict__),
+                        jobInfo.vm.id,
+                    )
                 )
                 raise Exception("Job %s is not running yet" % jobid)
             elif vm.id is None:
                 raise Exception("Job %s does not have a vm id set" % jobid)
-            
+
             vmms = self.preallocator.vmms[Config.VMMS_NAME]
             return vmms.getPartialOutput(vm)
         except Exception as err:

--- a/tango.py
+++ b/tango.py
@@ -221,8 +221,9 @@ class TangoServer(object):
 
             if not jobInfo.assigned or vm is None:
                 self.log.info(
-                        "job %s %d is assigned ?: %d %s]"
-                        % (jobInfo.name, jobInfo.id, jobInfo.assigned)
+                        "job %s %d is assigned ?: %d %s ID: %s]"
+                        % (jobInfo.name, jobInfo.id, jobInfo.assigned,
+                          str(jobInfo.__dict__), jobInfo.vm.id)
                 )
                 raise Exception("Job %s is not running yet" % jobid)
 

--- a/tango.py
+++ b/tango.py
@@ -226,7 +226,9 @@ class TangoServer(object):
                           str(jobInfo.__dict__), jobInfo.vm.id)
                 )
                 raise Exception("Job %s is not running yet" % jobid)
-
+            elif vm.id is None:
+                raise Exception("Job %s does not have a vm id set" % jobid)
+            
             vmms = self.preallocator.vmms[Config.VMMS_NAME]
             return vmms.getPartialOutput(vm)
         except Exception as err:

--- a/tango.py
+++ b/tango.py
@@ -91,8 +91,6 @@ class TangoServer(object):
         self.start_time = time.time()
         self.log = logging.getLogger("TangoServer")
         self.log.info("Starting Tango server")
-        if Config.USE_REDIS:
-            self.log.info("BRUHRUWEHUASERH")
 
     def addJob(self, job):
         """addJob - Add a job to the job queue"""
@@ -221,7 +219,7 @@ class TangoServer(object):
 
             if not jobInfo.assigned or vm is None:
                 self.log.info(
-                        "job %s %d is assigned ?: %d %s ID: %s]"
+                        "job %s %d is assigned %d, job dict: %s ID: %s]"
                         % (jobInfo.name, jobInfo.id, jobInfo.assigned,
                           str(jobInfo.__dict__), jobInfo.vm.id)
                 )

--- a/tangoObjects.py
+++ b/tangoObjects.py
@@ -118,6 +118,11 @@ class TangoJob(object):
         self.assigned = True
         self.updateRemote()
 
+    def makeVM(self, vm):
+        self.syncRemote()
+        self.vm = vm
+        self.updateRemote()
+
     def makeUnassigned(self):
         self.syncRemote()
         self.assigned = False

--- a/tests/testJobQueue.py
+++ b/tests/testJobQueue.py
@@ -93,11 +93,11 @@ class TestJobQueue(unittest.TestCase):
         self.assertEqual(str(ret_job_2.id), self.jobId2)
 
     def test_getNextPendingJob(self):
-        self.jobQueue.assignJob(self.jobId2, None)
+        self.jobQueue.assignJob(self.jobId2)
         # job 2 should have been removed from unassigned queue
         info = self.jobQueue.getInfo()
         self.assertEqual(info["size_unassignedjobs"], 1)
-        self.jobQueue.assignJob(self.jobId1, None)
+        self.jobQueue.assignJob(self.jobId1)
         info = self.jobQueue.getInfo()
         self.assertEqual(info["size_unassignedjobs"], 0)
         self.jobQueue.unassignJob(self.jobId1)
@@ -113,12 +113,12 @@ class TestJobQueue(unittest.TestCase):
         self.assertMultiLineEqual(str(job.id), self.jobId2)
 
     def test_assignJob(self):
-        self.jobQueue.assignJob(self.jobId1, None)
+        self.jobQueue.assignJob(self.jobId1)
         job = self.jobQueue.get(self.jobId1)
         self.assertFalse(job.isNotAssigned())
 
     def test_unassignJob(self):
-        self.jobQueue.assignJob(self.jobId1, None)
+        self.jobQueue.assignJob(self.jobId1)
         job = self.jobQueue.get(self.jobId1)
         self.assertTrue(job.assigned)
 

--- a/tests/testJobQueue.py
+++ b/tests/testJobQueue.py
@@ -93,11 +93,11 @@ class TestJobQueue(unittest.TestCase):
         self.assertEqual(str(ret_job_2.id), self.jobId2)
 
     def test_getNextPendingJob(self):
-        self.jobQueue.assignJob(self.jobId2)
+        self.jobQueue.assignJob(self.jobId2, None)
         # job 2 should have been removed from unassigned queue
         info = self.jobQueue.getInfo()
         self.assertEqual(info["size_unassignedjobs"], 1)
-        self.jobQueue.assignJob(self.jobId1)
+        self.jobQueue.assignJob(self.jobId1, None)
         info = self.jobQueue.getInfo()
         self.assertEqual(info["size_unassignedjobs"], 0)
         self.jobQueue.unassignJob(self.jobId1)
@@ -113,12 +113,12 @@ class TestJobQueue(unittest.TestCase):
         self.assertMultiLineEqual(str(job.id), self.jobId2)
 
     def test_assignJob(self):
-        self.jobQueue.assignJob(self.jobId1)
+        self.jobQueue.assignJob(self.jobId1, None)
         job = self.jobQueue.get(self.jobId1)
         self.assertFalse(job.isNotAssigned())
 
     def test_unassignJob(self):
-        self.jobQueue.assignJob(self.jobId1)
+        self.jobQueue.assignJob(self.jobId1, None)
         job = self.jobQueue.get(self.jobId1)
         self.assertTrue(job.assigned)
 

--- a/worker.py
+++ b/worker.py
@@ -175,8 +175,7 @@ class Worker(threading.Thread):
             # Assigning job to a preallocated VM
             if self.preVM:  # self.preVM:
                 self.log.debug("Assigning job to preallocated VM")
-                self.job.vm = self.preVM
-                self.job.updateRemote()
+                self.job.makeVM(self.preVM)
                 self.log.info(
                     "Assigned job %s:%d existing VM %s"
                     % (
@@ -198,8 +197,7 @@ class Worker(threading.Thread):
             # Assigning job to a new VM
             else:
                 self.log.debug("Assigning job to a new VM")
-                self.job.vm.id = self.job.id
-                self.job.updateRemote()
+                self.job.makeVM(self.job.id)
 
                 self.log.info(
                     "Assigned job %s:%d new VM %s"

--- a/worker.py
+++ b/worker.py
@@ -197,7 +197,9 @@ class Worker(threading.Thread):
             # Assigning job to a new VM
             else:
                 self.log.debug("Assigning job to a new VM")
-                self.job.makeVM(self.job.id)
+                self.job.syncRemote()
+                self.job.vm.id = self.job.id
+                self.job.updateRemote()
 
                 self.log.info(
                     "Assigned job %s:%d new VM %s"


### PR DESCRIPTION
## Description

Fixes an issue where jobs' assignment state (`assigned`) field are not consistent nor updated properly, resulting in a condition where a job is live, and is assigned and running on a VM, but the job in the `liveJobs` dictionary has `assigned==False`.

## Testing (local and docker-compose)

- Make multiple submissions of long running submissions
- check to see that partial output gets displayed and that the queue for submissions works
