### PR TITLE
[hotfix] Check element exists before removing for Python thread-safe queue

### DIFF
--- a/jobQueue.py
+++ b/jobQueue.py
@@ -253,11 +253,10 @@ class JobQueue(object):
 
         job = self.liveJobs.get(jobId)
 
-        # Remove the current job from the queue
-        self.unassignedJobs.remove(int(jobId))
 
         self.log.debug("assignJob| Retrieved job.")
         self.log.info("assignJob|Assigning job ID: %s" % str(job.id))
+        
         job.makeAssigned()
         job.makeVM(vm)
 

--- a/tangoObjects.py
+++ b/tangoObjects.py
@@ -230,7 +230,8 @@ class ExtendedQueue(Queue):
 
     def remove(self, value):
         with self.mutex:
-            self.queue.remove(value)
+            if value in self.queue:
+                self.queue.remove(value)
 
     def _clean(self):
         with self.mutex:


### PR DESCRIPTION
## Description
Fixes issue found in Tango deployments that use the default Python thread-safe queue instead of `TangoRemoteQueue`, where it was possible for `remove` to be called to remove an element already  removed from a queue, causing an unhandled exception. 

![image](https://user-images.githubusercontent.com/25730111/206362949-b5795b47-ed0b-4006-897b-393c8284771c.png)

This hotfix merely will check to see if the element exists in the queue before calling the `remove` method, which is consistent with `TangoRemoteQueue`, which does not raise an exception in the same scenario as well.


## Testing
- set `USE_REDIS=False` in `config.py`
- Run `python -m unittest tests/testJobQueue.py`, see all tests run successfully
- run only restful tango
- try uploading files to autograded assignment, see that they get graded properly