### PR TITLE
Add endpoint for uploading docker image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ scripts/*.sh
 # exclude
 vmms/id_rsa*
 courselabs/*
+dockerTmp/*
 # config
 config.py
 

--- a/clients/tango-cli.py
+++ b/clients/tango-cli.py
@@ -60,7 +60,9 @@ pool_help = "Obtain information about a pool of VMs spawned from a specific imag
 parser.add_argument("--pool", action="store_true", help=pool_help)
 prealloc_help = "Create a pool of instances spawned from a specific image. Must specify key with -k. Modify defaults with --image (autograding_image), --num (2), --vmms (localDocker), --cores (1), and --memory (512)."
 parser.add_argument("--prealloc", action="store_true", help=prealloc_help)
-build_help = "Build a docker image. Must specify key with -k and filename with --filename."
+build_help = (
+    "Build a docker image. Must specify key with -k and filename with --filename."
+)
 parser.add_argument("--build", action="store_true", help=build_help)
 
 parser.add_argument(

--- a/clients/tango-cli.py
+++ b/clients/tango-cli.py
@@ -502,30 +502,19 @@ def tango_build():
         response = requests.post(
             "%s://%s:%d/build/%s/"
             % (_tango_protocol, args.server, args.port, args.key),
-            data=f.read()
+            data=f.read(),
         )
-        print(
-            "Sent request to %s:%d/build/%s/"
-            % (
-                args.server,
-                args.port,
-                args.key
-            )
-        )
+        print("Sent request to %s:%d/build/%s/" % (args.server, args.port, args.key))
         print(response.text)
 
     except Exception as err:
         print(
             "Failed to send request to %s:%d/build/%s/"
-            % (
-                args.server,
-                args.port,
-                args.key
-            )
+            % (args.server, args.port, args.key)
         )
         print(str(err))
         sys.exit(0)
-    
+
 
 # runJob
 

--- a/config.template.py
+++ b/config.template.py
@@ -87,7 +87,7 @@ class Config(object):
     DOCKER_HOST_USER = ""
 
     # Maximum size for input files in bytes
-    MAX_INPUT_FILE_SIZE = 250 * 1024 * 1024  # 250MB
+    MAX_INPUT_FILE_SIZE = 10 * 1024 * 1024 * 1024  # 10GB
 
     # Maximum size for output file in bytes
     MAX_OUTPUT_FILE_SIZE = 1000 * 1024

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ redis==3.4.1
 requests==2.26.0
 # needed for tashi, rpyc==4.1.4
 tornado==4.5.3
+docker==6.1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ backports.ssl-match-hostname==3.7.0.1
 boto==2.49.0 # used only by ec2SSH.py
 pyflakes==2.1.1
 redis==4.4.4
-requests==2.31.0
+requests==2.28.0
 # needed for tashi, rpyc==4.1.4
 tornado==6.3.3
 docker==5.0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ redis==3.4.1
 requests==2.26.0
 # needed for tashi, rpyc==4.1.4
 tornado==4.5.3
-docker==6.1.3
+docker==5.0.3

--- a/restful_tango/server.py
+++ b/restful_tango/server.py
@@ -153,6 +153,13 @@ class PreallocHandler(tornado.web.RequestHandler):
         return tangoREST.prealloc(key, image, num, self.request.body)
 
 
+class BuildHandler(tornado.web.RequestHandler):
+    @unblock
+    def post(self, key, image):
+        """post - Handles the post request to build."""
+        return tangoREST.build(key, image, self.request.body)
+
+
 # Routes
 application = tornado.web.Application(
     [
@@ -166,6 +173,7 @@ application = tornado.web.Application(
         (r"/jobs/(%s)/(%s)/" % (SHA1_KEY, DEADJOBS), JobsHandler),
         (r"/pool/(%s)/" % (SHA1_KEY), PoolHandler),
         (r"/prealloc/(%s)/(%s)/(%s)/" % (SHA1_KEY, IMAGE, NUM), PreallocHandler),
+        (r"/build/(%s)/" % (SHA1_KEY), BuildHandler)
     ]
 )
 

--- a/restful_tango/server.py
+++ b/restful_tango/server.py
@@ -189,7 +189,7 @@ application = tornado.web.Application(
         (r"/jobs/(%s)/(%s)/" % (SHA1_KEY, DEADJOBS), JobsHandler),
         (r"/pool/(%s)/" % (SHA1_KEY), PoolHandler),
         (r"/prealloc/(%s)/(%s)/(%s)/" % (SHA1_KEY, IMAGE, NUM), PreallocHandler),
-        (r"/build/(%s)/" % (SHA1_KEY), BuildHandler)
+        (r"/build/(%s)/" % (SHA1_KEY), BuildHandler),
     ]
 )
 

--- a/restful_tango/tangoREST.py
+++ b/restful_tango/tangoREST.py
@@ -452,7 +452,7 @@ class TangoREST(object):
                 images = client.images.load(imageTarStr)
                 id_list = ", ".join(image.short_id for image in images)
             except Exception as e:
-                self.log.error("Image build failed")
+                self.log.error("Image build failed: " + str(e))
                 os.unlink(tempfile)
                 return self.status.image_build_failed
 

--- a/restful_tango/tangoREST.py
+++ b/restful_tango/tangoREST.py
@@ -445,11 +445,11 @@ class TangoREST(object):
 
     def build(self, key, tempfile):
         self.log.debug("Received build request(%s)" % (key))
-        if Config.VMMS_NAME != "localDocker":
-            self.log.error("Not using Docker backend, so cannot build image")
-            os.unlink(tempfile)
-            return "test"
         if self.validateKey(key):
+            if Config.VMMS_NAME != "localDocker":
+                self.log.error("Not using Docker backend, so cannot build image")
+                os.unlink(tempfile)
+                return self.status.image_build_failed
             try:
                 client = docker.from_env()
                 imageTarStr = open(tempfile, "rb").read()

--- a/restful_tango/tangoREST.py
+++ b/restful_tango/tangoREST.py
@@ -442,20 +442,20 @@ class TangoREST(object):
         else:
             self.log.info("Key not recognized: %s" % key)
             return self.status.wrong_key
-    
+
     def build(self, key, tempfile):
         self.log.debug("Received build request(%s)" % (key))
-        if self.validateKey(key):   
+        if self.validateKey(key):
             try:
                 client = docker.from_env()
                 imageTarStr = open(tempfile, "rb").read()
                 images = client.images.load(imageTarStr)
-                id_list = ', '.join(image.short_id for image in images)
+                id_list = ", ".join(image.short_id for image in images)
             except Exception as e:
                 self.log.error("Image build failed")
                 os.unlink(tempfile)
                 return self.status.image_build_failed
-            
+
             self.log.info("Successfully loaded images: %s" % (id_list))
             os.unlink(tempfile)
             return self.status.image_built

--- a/restful_tango/tangoREST.py
+++ b/restful_tango/tangoREST.py
@@ -445,6 +445,10 @@ class TangoREST(object):
 
     def build(self, key, tempfile):
         self.log.debug("Received build request(%s)" % (key))
+        if Config.VMMS_NAME != "localDocker":
+            self.log.error("Not using Docker backend, so cannot build image")
+            os.unlink(tempfile)
+            return "test"
         if self.validateKey(key):
             try:
                 client = docker.from_env()


### PR DESCRIPTION
## Description

- Added endpoint for uploading a docker image tar created using `docker save`. 
- The maximum file upload size was increased from 250 MB to 10 GB, which may be a concern for assignment uploads. 
- Updated tango client script to utilize the new endpoint.
- Corresponding [Autolab PR](https://github.com/autolab/Autolab/pull/2013).

## Testing
- Used the updated `clients/tango-cli.py` to upload and build a new docker image.
- Verified that bad file submissions are error reported properly, and do not crash Tango.