### PR TITLE
Update Dockerfile to use Ubuntu 20.04, Update dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Start with empty ubuntu machine
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 MAINTAINER Autolab Development Team "autolab-dev@andrew.cmu.edu"
 
@@ -24,9 +24,9 @@ RUN apt-get update && apt-get install -y \
 	python3 \
 	python3-pip \
 	build-essential \
-	tcl8.5 \
+	tcl8.6 \
 	wget \
-	libgcrypt11-dev \
+	libgcrypt20-dev \
 	zlib1g-dev \
 	apt-transport-https \
 	ca-certificates \


### PR DESCRIPTION
#230 updated redis from 3.4.1 to 4.4.4, however Python3 on Ubuntu 18.04 has a version of 3.6.x while `redis-py` requires a version >= 3.7. Ubuntu 20.04 comes with Python 3.8, so this PR bumps up Ubuntu in order to keep the Tango container for Docker working.

Also updated Ubuntu libraries to be compatible with 20.04:
- `tcl` from 8.5 to 8.6
- `libgcrypt-dev` from 11 to 20

Verified by building container on Nightly, and running an autograded job and ensuring job completed successfully.