### PR TITLE
Add docker resource limits for jobs

### DIFF
--- a/config.template.py
+++ b/config.template.py
@@ -86,6 +86,10 @@ class Config(object):
     DOCKER_RM_TIMEOUT = 5
     DOCKER_HOST_USER = ""
 
+    # Docker autograding container resource limits
+    DOCKER_CORES_LIMIT = None
+    DOCKER_MEMORY_LIMIT = None  # in MB
+
     # Maximum size for input files in bytes
     MAX_INPUT_FILE_SIZE = 10 * 1024 * 1024 * 1024  # 10GB
 

--- a/restful_tango/tangoREST.py
+++ b/restful_tango/tangoREST.py
@@ -113,8 +113,8 @@ class TangoREST(object):
 
     def createTangoMachine(self, image, vmms=Config.VMMS_NAME, vmObj=None):
         """createTangoMachine - Creates a tango machine object from image"""
-        cores = Config.DOCKER_CORES_LIMIT
-        memory = Config.DOCKER_MEMORY_LIMIT
+        cores = getattr(Config, "DOCKER_CORES_LIMIT", None)
+        memory = getattr(Config, "DOCKER_MEMORY_LIMIT", None)
         if vmObj and "cores" in vmObj and "memory" in vmObj:
             cores = vmObj["cores"]
             memory = vmObj["memory"]

--- a/restful_tango/tangoREST.py
+++ b/restful_tango/tangoREST.py
@@ -153,7 +153,16 @@ class TangoREST(object):
             input.append(handinfile)
 
         # VM object
-        vm = self.createTangoMachine(jobObj["image"])
+        if "cores" in jobObj and "memory" in jobObj:
+            vm = self.createTangoMachine(
+                jobObj["image"],
+                vmObj={
+                    "cores": jobObj["cores"],
+                    "memory": jobObj["memory"],
+                },
+            )
+        else:
+            vm = self.createTangoMachine(jobObj["image"])
 
         # for backward compatibility
         accessKeyId = None

--- a/restful_tango/tangoREST.py
+++ b/restful_tango/tangoREST.py
@@ -111,16 +111,19 @@ class TangoREST(object):
                 except IOError:
                     continue
 
-    def createTangoMachine(
-        self, image, vmms=Config.VMMS_NAME, vmObj={"cores": 1, "memory": 512}
-    ):
+    def createTangoMachine(self, image, vmms=Config.VMMS_NAME, vmObj=None):
         """createTangoMachine - Creates a tango machine object from image"""
+        cores = Config.DOCKER_CORES_LIMIT
+        memory = Config.DOCKER_MEMORY_LIMIT
+        if vmObj and "cores" in vmObj and "memory" in vmObj:
+            cores = vmObj["cores"]
+            memory = vmObj["memory"]
         return TangoMachine(
             name=image,
             vmms=vmms,
             image="%s" % (image),
-            cores=vmObj["cores"],
-            memory=vmObj["memory"],
+            cores=cores,
+            memory=memory,
             disk=None,
             network=None,
         )
@@ -153,16 +156,7 @@ class TangoREST(object):
             input.append(handinfile)
 
         # VM object
-        if "cores" in jobObj and "memory" in jobObj:
-            vm = self.createTangoMachine(
-                jobObj["image"],
-                vmObj={
-                    "cores": jobObj["cores"],
-                    "memory": jobObj["memory"],
-                },
-            )
-        else:
-            vm = self.createTangoMachine(jobObj["image"])
+        vm = self.createTangoMachine(jobObj["image"])
 
         # for backward compatibility
         accessKeyId = None

--- a/vmms/localDocker.py
+++ b/vmms/localDocker.py
@@ -157,8 +157,10 @@ class LocalDocker(object):
             )
         args = ["docker", "run", "--name", instanceName, "-v"]
         args = args + ["%s:%s" % (volumePath, "/home/mount")]
-        args = args + [f"--cpus={vm.cores}"]
-        args = args + ["-m", f"{vm.memory}m"]
+        if vm.cores:
+            args = args + [f"--cpus={vm.cores}"]
+        if vm.memory:
+            args = args + ["-m", f"{vm.memory}m"]
         args = args + [vm.image]
         args = args + ["sh", "-c"]
 

--- a/vmms/localDocker.py
+++ b/vmms/localDocker.py
@@ -157,6 +157,8 @@ class LocalDocker(object):
             )
         args = ["docker", "run", "--name", instanceName, "-v"]
         args = args + ["%s:%s" % (volumePath, "/home/mount")]
+        args = args + [f"--cpus={vm.cores}"]
+        args = args + ["-m", f"{vm.memory}m"]
         args = args + [vm.image]
         args = args + ["sh", "-c"]
 


### PR DESCRIPTION
Adds the following resource limits to new jobs:
- Number of CPU cores
- Memory (in MB)

Addresses: @139

Resource limits can be verified using `docker stats` and `htop`. 