### PR TITLE
Fix prealloc 500 error by making prealloc in tangoREST.py async

### DIFF
--- a/restful_tango/tangoREST.py
+++ b/restful_tango/tangoREST.py
@@ -416,7 +416,7 @@ class TangoREST(object):
             self.log.info("Key not recognized: %s" % key)
             return self.status.wrong_key
 
-    def prealloc(self, key, image, num, vmStr):
+    async def prealloc(self, key, image, num, vmStr):
         """prealloc - Create a pool of num instances spawned from image"""
         self.log.debug("Received prealloc request(%s, %s, %s)" % (key, image, num))
         if self.validateKey(key):


### PR DESCRIPTION
Fixes #242. Tested by running `pathon tango-cli.py -k [KEY] --prealloc --num [count] --image [image] --vmms localDocker` within `Tango/clients/`