### PR TITLE
Fix urllib version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,5 @@ redis==4.4.4
 requests==2.31.0
 # needed for tashi, rpyc==4.1.4
 tornado==6.3.3
+urllib3==1.26.18
 docker==5.0.3


### PR DESCRIPTION
# Description
Fix urllib version to below 2 so that the `requests` library can be safely updated (which should take precedence due to security concerns with the current version).

# Testing
- Tested build endpoint (only one that uses `docker-py`) using `tango-cli.py`
