### PR TITLE
adding load_dotenv() to properly load environment variables

### DIFF
--- a/config.template.py
+++ b/config.template.py
@@ -8,6 +8,9 @@ import time
 # Config - defines
 import os
 
+# loads environment variables from a .env file into os.environ
+from dotenv import load_dotenv
+load_dotenv() 
 
 class Config(object):
     #####

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ requests==2.32.0
 tornado==6.3.3
 urllib3==1.26.18
 docker==5.0.3
+python-dotenv==1.0.1


### PR DESCRIPTION
Had  issue with environment variables not loading in properly. Used dotenv library to 

Changes:
- added dotenv to requirements.txt
- called load_dotenv in config to force load the environment variables.


[Issue described in slack](https://autolab.slack.com/archives/C5RFK99RC/p1719521040094649)


