### PR TITLE
Get Partial Output working

### DIFF
--- a/vmms/ec2SSH.py
+++ b/vmms/ec2SSH.py
@@ -651,3 +651,19 @@ class Ec2SSH(object):
                 if tag["Key"] == tagKey:
                     return tag["Value"]
         return None
+    
+    def getPartialOutput(self, vm):
+        domain_name = self.domainName(vm)
+
+        runcmd = "head -c %s /home/autograde/output.log" % (config.Config.MAX_OUTPUT_FILE_SIZE)
+
+        sshcmd = ["ssh"] + self.ssh_flags + ["%s@%s" % (self.ec2User, domain_name), runcmd]
+
+        output = subprocess.check_output(
+            sshcmd, stderr=subprocess.STDOUT
+        ).decode("utf-8")
+
+        self.log.debug(output)
+
+        return output
+

--- a/vmms/ec2SSH.py
+++ b/vmms/ec2SSH.py
@@ -663,7 +663,5 @@ class Ec2SSH(object):
             sshcmd, stderr=subprocess.STDOUT
         ).decode("utf-8")
 
-        self.log.debug(output)
-
         return output
 


### PR DESCRIPTION
Created a new get partial output function in EC2SSH vmms, adapting the code from the localDocker vmms

Tested using this autograder (unzip the file to get the tar, github didn't support tar files):
[randomlab-partial (1).zip](https://github.com/user-attachments/files/17851871/randomlab-partial.1.zip)

Result:
![image](https://github.com/user-attachments/assets/c747a82a-c069-4626-86b9-210794c17aa7)

