### PR TITLE
Add keypair functionality for ec2ssh.py

### DIFF
--- a/vmms/ec2SSH.py
+++ b/vmms/ec2SSH.py
@@ -76,7 +76,21 @@ def timeoutWithReturnStatus(command, time_out, returnValue=0):
             )
             return ret
 
-
+def checkAWSCredentials(access_key_id, secret_access_key):
+    try:
+        # Initialize a session with the provided keys
+        session = boto3.session.Session(
+            aws_access_key_id=access_key_id,
+            aws_secret_access_key=secret_access_key
+        )
+        
+        # Use STS to check if credentials are valid
+        sts_client = session.client('sts')
+        sts_client.get_caller_identity()
+    except Exception as e:
+        return False
+    return True
+            
 #
 # User defined exceptions
 #
@@ -130,6 +144,11 @@ class Ec2SSH(object):
         self.images = []
         try:
             self.boto3resource = boto3.resource("ec2", config.Config.EC2_REGION)
+            if accessKeyId != None:
+                if(checkAWSCredentials(accessKeyId, accessKey)):
+                    self.log.info("joys-------------AWS VALID")
+                else:
+                    self.log.info("joys-------------AWS NOT VALID")
             # should work according to documentation
             # if parameters passed in as None, will continue to be passed in as None
             self.log.info("joys-------------started creating client with accessid")

--- a/vmms/ec2SSH.py
+++ b/vmms/ec2SSH.py
@@ -118,6 +118,7 @@ class Ec2SSH(object):
         self.ec2User = config.Config.EC2_USER_NAME
         # use default if accessKeyId/accessKey not provided by user
         # to access another aws account
+        # TODO: add testing to make sure accessKeyId and accessKey valid
         self.useDefaultKeyPair = False if accessKeyId else True
         self.log.info("joys-------------DefaultKeyPair: "+str(self.useDefaultKeyPair))
 

--- a/vmms/ec2SSH.py
+++ b/vmms/ec2SSH.py
@@ -76,21 +76,6 @@ def timeoutWithReturnStatus(command, time_out, returnValue=0):
             )
             return ret
 
-def checkAWSCredentials(access_key_id, secret_access_key):
-    try:
-        # Initialize a session with the provided keys
-        session = boto3.session.Session(
-            aws_access_key_id=access_key_id,
-            aws_secret_access_key=secret_access_key
-        )
-        
-        # Use STS to check if credentials are valid
-        sts_client = session.client('sts')
-        sts_client.get_caller_identity()
-    except Exception as e:
-        return False
-    return True
-            
 #
 # User defined exceptions
 #
@@ -144,11 +129,6 @@ class Ec2SSH(object):
         self.images = []
         try:
             self.boto3resource = boto3.resource("ec2", config.Config.EC2_REGION)
-            if accessKeyId != None:
-                if(checkAWSCredentials(accessKeyId, accessKey)):
-                    self.log.info("joys-------------AWS VALID")
-                else:
-                    self.log.info("joys-------------AWS NOT VALID")
             # should work according to documentation
             # if parameters passed in as None, will continue to be passed in as None
             self.log.info("joys-------------started creating client with accessid")

--- a/vmms/ec2SSH.py
+++ b/vmms/ec2SSH.py
@@ -96,6 +96,8 @@ class Ec2SSH(object):
         "-o",
         "GSSAPIAuthentication no",
     ]
+    
+    _SECURITY_KEY_PATH_INDEX_IN_SSH_FLAGS = 1
 
     def __init__(self, accessKeyId=None, accessKey=None):
         """log - logger for the instance
@@ -114,7 +116,10 @@ class Ec2SSH(object):
         # user for now
         self.ssh_flags = Ec2SSH._SSH_FLAGS
         self.ec2User = config.Config.EC2_USER_NAME
-        self.useDefaultKeyPair = True
+        # use default if accessKeyId/accessKey not provided by user
+        # to access another aws account
+        self.useDefaultKeyPair = False if accessKeyId else True
+        self.log.info("joys-------------DefaultKeyPair: "+str(self.useDefaultKeyPair))
 
         # key pair settings, for now, use default security key
 
@@ -124,8 +129,11 @@ class Ec2SSH(object):
         self.images = []
         try:
             self.boto3resource = boto3.resource("ec2", config.Config.EC2_REGION)
-            # idk if works
-            self.boto3client = boto3.client("ec2", config.Config.EC2_REGION)
+            # should work according to documentation
+            # if parameters passed in as None, will continue to be passed in as None
+            self.log.info("joys-------------started creating client with accessid")
+            self.boto3client = boto3.client("ec2", config.Config.EC2_REGION,
+                    aws_access_key_id=accessKeyId, aws_secret_access_key=accessKey)
 
             # Get images from ec2
             images = self.boto3resource.images.filter(Owners=["self"])
@@ -220,28 +228,66 @@ class Ec2SSH(object):
         return ec2instance
 
     def createKeyPair(self):
+        self.log.info("joys-------------Entered create Key Pair")
         # TODO: SUPPORT
-        raise
-        # try to delete the key to avoid collision
-        self.key_pair_path = "%s/%s.pem" % (
-            config.Config.DYNAMIC_SECURITY_KEY_PATH,
-            self.key_pair_name,
-        )
+        # boto requires keyName, does not require KeyType (rsa is default)
+        # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ec2/client/create_key_pair.html
+        self.key_pair_path = "%s/%s.pem" % \
+                             (config.Config.DYNAMIC_SECURITY_KEY_PATH,
+                              self.key_pair_name)
+        # delete key pair with same name if it exists
         self.deleteKeyPair()
-        key = self.connection.create_key_pair(self.key_pair_name)
-        key.save(config.Config.DYNAMIC_SECURITY_KEY_PATH)
-        # change the SSH_FLAG accordingly
-        self.ssh_flags[1] = self.key_pair_path
+        self.log.info("joys-------------Returned from trying to delete key pair")
+        # create new key pair with the unique key pair name created
+        response = self.boto3client.create_key_pair(KeyName=self.key_pair_name)
+        self.log.info("joys-------------New key pair created")
+        # Ensure the directory exists
+        directory = os.path.dirname(self.key_pair_path)
+        if not os.path.exists(directory):
+            os.makedirs(directory)
+        # securely store private key material
+        self.log.info("joys-------------key pair path: "+str(self.key_pair_path))
+        keyFile = open(self.key_pair_path, "w+")
+        self.log.info("joys-------------writing...")
+        keyFile.write(response["KeyMaterial"]) # "KeyMaterial" contains the private key
+        os.chmod(self.key_pair_path, 0o600)  # only owner can view
+        keyFile.close()
+        self.log.info("joys-------------done storing private key material")
 
+        # change the SSH_FLAG accordingly, point to newly created private key file
+        self.ssh_flags[Ec2SSH._SECURITY_KEY_PATH_INDEX_IN_SSH_FLAGS] = self.key_pair_path
+        self.log.info("joys-------------done redirecting new private key material")
+        self.log.info("joys-------------key_pair_path: "+str(self.key_pair_path))
+        return self.key_pair_path
+    
     def deleteKeyPair(self):
-        # TODO: SUPPORT
-        raise
-        self.boto3client.delete_key_pair(self.key_pair_name)
-        # try to delete may not exist key file
+        self.log.info("joys-------------Entered delete Key Pair")
+
+        # Delete the key pair in AWS
+        try:
+            self.boto3client.delete_key_pair(KeyName=self.key_pair_name)
+            self.log.info(f"Deleted key pair '{self.key_pair_name}' in AWS.")
+        except self.boto3client.exceptions.ClientError as e:
+            self.log.info(f"Error deleting key pair '{self.key_pair_name}' in AWS: {e}")
+
+        # Delete the key file locally
         try:
             os.remove(self.key_pair_path)
+            self.log.info(f"Deleted key file at '{self.key_pair_path}'.")
         except OSError:
+            self.log.info("joys-------------Error - encountered issue when deleting key pair locally")
             pass
+
+        # Check if the key pair still exists in AWS
+        try:
+            # Attempt to describe the key pair
+            self.boto3client.describe_key_pairs(KeyNames=[self.key_pair_name])
+            self.log.info(f"joys-------------Key pair '{self.key_pair_name}' still exists in AWS.")
+        except self.boto3client.exceptions.ClientError as e:
+            if "InvalidKeyPair.NotFound" in str(e):
+                self.log.info(f"joys-------------Key pair '{self.key_pair_name}' successfully deleted.")
+            else:
+                self.log.info(f"joys-------------Unexpected error when checking key pair: {e}")
 
     def createSecurityGroup(self):
         # Create may-exist security group
@@ -273,15 +319,19 @@ class Ec2SSH(object):
             self.log.debug("instanceName: %s" % instanceName)
             # ensure that security group exists
             self.createSecurityGroup()
+            self.log.info("joys-------------useDefault: "+str(self.useDefaultKeyPair))
+            # an EC2 instance can only be associated with one active keypair
             if self.useDefaultKeyPair:
                 self.key_pair_name = config.Config.SECURITY_KEY_NAME
                 self.key_pair_path = config.Config.SECURITY_KEY_PATH
             else:
-                # TODO: SUPPORT
-                raise
+                self.log.info("joys-------------HELLLOOO")
+                self.log.info("joys-------------Own Key Pair Created")
                 self.key_pair_name = self.keyPairName(vm.id, vm.name)
-                self.createKeyPair()
+                self.key_pair_path = self.createKeyPair()
+                self.log.info("joys-------------Own Key Pair Created DONE")
 
+            self.log.info("joys-------------Reached Here0")
             reservation = self.boto3resource.create_instances(
                 ImageId=ec2instance["ami"],
                 KeyName=self.key_pair_name,
@@ -291,10 +341,12 @@ class Ec2SSH(object):
                 MinCount=1,
             )
 
+            self.log.info("joys-------------Reached Here1")
             # Sleep for a while to prevent random transient errors observed
             # when the instance is not available yet
             time.sleep(config.Config.TIMER_POLL_INTERVAL)
 
+            self.log.info("joys-------------Reached Here2")
             # reservation is a list of instances created. there is only
             # one instance created so get index 0.
             newInstance = reservation[0]

--- a/vmms/ec2SSH.py
+++ b/vmms/ec2SSH.py
@@ -116,7 +116,7 @@ class Ec2SSH(object):
         self.ec2User = config.Config.EC2_USER_NAME
         # use default if accessKeyId/accessKey not provided by user
         # to access another aws account
-        self.useDefaultKeyPair = False if accessKeyId else True
+        self.useDefaultKeyPair = False if (accessKeyId and accessKey) else True
         self.log.info("Is DefaultKeyPair used: "+str(self.useDefaultKeyPair))
 
         # key pair settings, for now, use default security key

--- a/worker.py
+++ b/worker.py
@@ -167,6 +167,7 @@ class Worker(threading.Thread):
             print("HELLO")
             self.log.debug("Run worker")
             vm = None
+
             # Header message for user
             hdrfile = tempfile.mktemp()
             self.appendMsg(hdrfile, "Received job %s:%d" % (self.job.name, self.job.id))

--- a/worker.py
+++ b/worker.py
@@ -166,7 +166,7 @@ class Worker(threading.Thread):
             ret["copyout"] = None
             self.log.debug("Run worker")
             vm = None
-
+            print("HELLO")
             # Header message for user
             hdrfile = tempfile.mktemp()
             self.appendMsg(hdrfile, "Received job %s:%d" % (self.job.name, self.job.id))

--- a/worker.py
+++ b/worker.py
@@ -166,7 +166,6 @@ class Worker(threading.Thread):
             ret["copyout"] = None
             self.log.debug("Run worker")
             vm = None
-            print("HELLO")
             # Header message for user
             hdrfile = tempfile.mktemp()
             self.appendMsg(hdrfile, "Received job %s:%d" % (self.job.name, self.job.id))

--- a/worker.py
+++ b/worker.py
@@ -164,6 +164,7 @@ class Worker(threading.Thread):
             ret["copyin"] = None
             ret["runjob"] = None
             ret["copyout"] = None
+            print("HELLO")
             self.log.debug("Run worker")
             vm = None
             # Header message for user

--- a/worker.py
+++ b/worker.py
@@ -164,7 +164,6 @@ class Worker(threading.Thread):
             ret["copyin"] = None
             ret["runjob"] = None
             ret["copyout"] = None
-            print("HELLO")
             self.log.debug("Run worker")
             vm = None
 


### PR DESCRIPTION
Allows connecting to other EC2 instances besides the default one provided.

How to use:
If the flags --accessKeyId and --accessKey are passed in when running, their values will be used as the access credentials. 
If the flags are not passed in, the default key-pair will be used. 
Example: python3 tango-cli.py -P 3000 -k ec2test -l test1 --runJob job1 --image autograding_image --accessKeyId TEST --accessKey TEST

How Tested:
Tested by not including at least one of the flags. Should just use the default key-pair.
Tested by using invalid AWS credentials for flag inputs. As expected, will realize this issue when trying to apply the credentials.
Tested by using the same credentials for the flag inputs as the default keypair values. Same output.
