### PR TITLE
Change how docker run args are built

### DIFF
--- a/vmms/distDocker.py
+++ b/vmms/distDocker.py
@@ -271,15 +271,6 @@ class DistDocker(object):
                 self.log.debug("Lost persistent SSH connection")
                 return ret
 
-        autodriverCmd = (
-            "autodriver -u %d -f %d -t %d -o %d autolab > output/feedback 2>&1"
-            % (
-                config.Config.VM_ULIMIT_USER_PROC,
-                config.Config.VM_ULIMIT_FILE_SIZE,
-                runTimeout,
-                config.Config.MAX_OUTPUT_FILE_SIZE,
-            )
-        )
         args = ["docker", "run", "--name", instanceName, "-v"]
         args.append("%s:%s" % (volumePath, "/home/mount"))
         if vm.cores:
@@ -291,6 +282,14 @@ class DistDocker(object):
 
         args.append(vm.image)
         args.extend(("sh", "-c"))
+
+        autodriverCmd = (
+            f"autodriver -u {config.Config.VM_ULIMIT_USER_PROC} "
+            f"-f {config.Config.VM_ULIMIT_FILE_SIZE} "
+            f"-t {runTimeout} -o {config.Config.MAX_OUTPUT_FILE_SIZE} "
+            "autolab > output/feedback 2>&1"
+        )
+
         args.append(
             f"\"cp -r mount/* autolab/; su autolab -c '{autodriverCmd}'; \
                         cp output/feedback mount/feedback\""

--- a/vmms/distDocker.py
+++ b/vmms/distDocker.py
@@ -285,9 +285,9 @@ class DistDocker(object):
         if vm.cores:
             args.append(f"--cpus={vm.cores}")
         if vm.memory:
-            args.extend(("-m", f"{vm.memory}m"))
+            args.append(f"--memory={vm.memory}m")
         if disableNetwork:
-            args.append("--network", "none")
+            args.append("--network=none")
 
         args.append(vm.image)
         args.extend(("sh", "-c"))

--- a/vmms/localDocker.py
+++ b/vmms/localDocker.py
@@ -167,13 +167,10 @@ class LocalDocker(object):
         args.extend(("sh", "-c"))
 
         autodriverCmd = (
-            "autodriver -u %d -f %d -t %d -o %d autolab > output/feedback 2>&1"
-            % (
-                config.Config.VM_ULIMIT_USER_PROC,
-                config.Config.VM_ULIMIT_FILE_SIZE,
-                runTimeout,
-                config.Config.MAX_OUTPUT_FILE_SIZE,
-            )
+            f"autodriver -u {config.Config.VM_ULIMIT_USER_PROC} "
+            f"-f {config.Config.VM_ULIMIT_FILE_SIZE} "
+            f"-t {runTimeout} -o {config.Config.MAX_OUTPUT_FILE_SIZE} "
+            "autolab > output/feedback 2>&1"
         )
 
         args.append(

--- a/vmms/localDocker.py
+++ b/vmms/localDocker.py
@@ -160,9 +160,9 @@ class LocalDocker(object):
         if vm.cores:
             args.append(f"--cpus={vm.cores}")
         if vm.memory:
-            args.extend(("-m", f"{vm.memory}m"))
+            args.append(f"--memory{vm.memory}m")
         if disableNetwork:
-            args.append("--network", "none")
+            args.append("--network=none")
         args.append(vm.image)
         args.extend(("sh", "-c"))
 

--- a/vmms/localDocker.py
+++ b/vmms/localDocker.py
@@ -156,15 +156,15 @@ class LocalDocker(object):
                 os.getenv("DOCKER_TANGO_HOST_VOLUME_PATH"), instanceName
             )
         args = ["docker", "run", "--name", instanceName, "-v"]
-        args = args + ["%s:%s" % (volumePath, "/home/mount")]
+        args.append("%s:%s" % (volumePath, "/home/mount"))
         if vm.cores:
-            args = args + [f"--cpus={vm.cores}"]
+            args.append(f"--cpus={vm.cores}")
         if vm.memory:
-            args = args + ["-m", f"{vm.memory}m"]
+            args.extend(("-m", f"{vm.memory}m"))
         if disableNetwork:
-            args = args + ["--network", "none"]
-        args = args + [vm.image]
-        args = args + ["sh", "-c"]
+            args.append("--network", "none")
+        args.append(vm.image)
+        args.extend(("sh", "-c"))
 
         autodriverCmd = (
             "autodriver -u %d -f %d -t %d -o %d autolab > output/feedback 2>&1"
@@ -176,11 +176,11 @@ class LocalDocker(object):
             )
         )
 
-        args = args + [
+        args.append(
             'cp -r mount/* autolab/; su autolab -c "%s"; \
                         cp output/feedback mount/feedback'
             % autodriverCmd
-        ]
+        )
 
         self.log.debug("Running job: %s" % str(args))
         ret = timeout(args, runTimeout * 2)


### PR DESCRIPTION
There are 2 changes here
- Redoes distDocker:runJob to look more like localDocker:runJob. I did this so I could stop maintaining a patch that manually inserts a --memory switch in distDocker
- makes localDocker's runJob use list.append instead of + to build up the list. When I copied the code, I wanted to make it more pythonic

This isn't tested yet. I'll try to do that by next tuesday or so.