### PR TITLE
Allow specifying the docker network

### DIFF
--- a/config.template.py
+++ b/config.template.py
@@ -89,6 +89,8 @@ class Config(object):
     # Docker autograding container resource limits
     DOCKER_CORES_LIMIT = None
     DOCKER_MEMORY_LIMIT = None  # in MB
+    # Docker network to attach to (must already exist)
+    DOCKER_NETWORK = None
 
     # Maximum size for input files in bytes
     MAX_INPUT_FILE_SIZE = 10 * 1024 * 1024 * 1024  # 10GB

--- a/restful_tango/tangoREST.py
+++ b/restful_tango/tangoREST.py
@@ -115,9 +115,14 @@ class TangoREST(object):
         """createTangoMachine - Creates a tango machine object from image"""
         cores = getattr(Config, "DOCKER_CORES_LIMIT", None)
         memory = getattr(Config, "DOCKER_MEMORY_LIMIT", None)
+        docker_network = getattr(Config, "DOCKER_NETWORK", None)
+        if docker_network:
+            network = {"docker_attachment": docker_network}
         if vmObj and "cores" in vmObj and "memory" in vmObj:
             cores = vmObj["cores"]
             memory = vmObj["memory"]
+        if vmObj and "network" in vmObj:
+            network = vmObj["network"]
         return TangoMachine(
             name=image,
             vmms=vmms,
@@ -125,7 +130,7 @@ class TangoREST(object):
             cores=cores,
             memory=memory,
             disk=None,
-            network=None,
+            network=network,
         )
 
     def convertJobObj(self, dirName, jobObj):

--- a/vmms/localDocker.py
+++ b/vmms/localDocker.py
@@ -11,6 +11,7 @@ import threading
 import os
 import sys
 import shutil
+from collections.abc import Mapping
 import config
 from tangoObjects import TangoMachine
 
@@ -163,6 +164,12 @@ class LocalDocker(object):
             args = args + ["-m", f"{vm.memory}m"]
         if disableNetwork:
             args = args + ["--network", "none"]
+        elif (
+            vm.network
+            and isinstance(vm.network, Mapping)
+            and "docker_attachment" in vm.network
+        ):
+            args.append("--network", vm.network["docker_attachment"])
         args = args + [vm.image]
         args = args + ["sh", "-c"]
 


### PR DESCRIPTION
Allow for the use of docker networks other than "bridge" and "none" for for autograding containers. The network name can be specified in config.py or via the preallocator. The network must exist on the target docker host for the containers to run.

- not yet tested
- distDocker patch not included, since
- final version will depend on #267 