### PR TITLE
Allow AMI and Security Group selection (in combination with PR on Autolab)

### DIFF
--- a/jobManager.py
+++ b/jobManager.py
@@ -81,7 +81,7 @@ class JobManager(object):
                     newVM = copy.deepcopy(job.vm)
                     newVM.id = self._getNextID()
                     try:
-                        preVM = vmms.initializeVM(newVM)
+                        preVM = vmms.initializeVM(newVM, ami = job.ami, security_group = job.security_group)
                     except Exception as e:
                         self.log.error("ERROR initialization VM: %s", e)
                         self.log.error(traceback.format_exc())

--- a/restful_tango/tangoREST.py
+++ b/restful_tango/tangoREST.py
@@ -165,8 +165,10 @@ class TangoREST(object):
             input.append(handinfile)
 
         ec2_vmms = False
-        if "ec2Vmms" in jobObj:
+        if Config.VMMS_NAME == "ec2SSH":
             ec2_vmms = True
+        if "ec2Vmms" in jobObj:
+            ec2_vmms = jobObj["ec2Vmms"]
 
         instance_type = None
         if "instanceType" in jobObj and len(jobObj["instanceType"]) > 0:
@@ -182,6 +184,14 @@ class TangoREST(object):
         if "accessKey" in jobObj and len(jobObj["accessKey"]) > 0:
             accessKeyId = jobObj["accessKeyId"]
             accessKey = jobObj["accessKey"]
+        
+        ami = None
+        if "ami" in jobObj and len(jobObj["ami"]) > 0:
+            ami = jobObj["ami"]
+            
+        security_group = None
+        if "security_group" in jobObj and len(jobObj["security_group"]) > 0:
+            security_group = jobObj["security_group"]
 
         disableNetwork = False
         if "disable_network" in jobObj and isinstance(jobObj["disable_network"], bool):
@@ -197,6 +207,8 @@ class TangoREST(object):
             maxOutputFileSize=maxOutputFileSize,
             accessKey=accessKey,
             accessKeyId=accessKeyId,
+            ami = ami,
+            security_group = security_group,
             disableNetwork=disableNetwork,
         )
 

--- a/tangoObjects.py
+++ b/tangoObjects.py
@@ -99,6 +99,8 @@ class TangoJob(object):
         maxOutputFileSize=Config.MAX_OUTPUT_FILE_SIZE,
         accessKeyId=None,
         accessKey=None,
+        ami = None,
+        security_group = None,
         disableNetwork=None,
     ):
         self.assigned = False
@@ -119,6 +121,8 @@ class TangoJob(object):
         self._remoteLocation = None
         self.accessKeyId = accessKeyId
         self.accessKey = accessKey
+        self.ami = ami
+        self.security_group = security_group
         self.disableNetwork = disableNetwork
 
     def __repr__(self):


### PR DESCRIPTION
- Retrieves available AMIs and existing security groups on Tango side and passes to Autolab for user to select.
- Whenever a job is added to Tango, the currently requested AMI and security groups are passed along
   - used for VM if not default
   - otherwise, just the existing default on Tango side (thus should not break anything, just give users options)