### PR TITLE
Fix Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,18 @@ RUN apt-get update && apt-get install -y \
 WORKDIR /opt/TangoService/Tango/
 
 # Install Docker from Docker Inc. repositories.
-RUN curl -sSL https://get.docker.com/ -o get_docker.sh && sh get_docker.sh
+RUN set -eux; \
+    apt-get update; \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ca-certificates curl gnupg; \
+    install -m 0755 -d /etc/apt/keyrings; \
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc; \
+    chmod a+r /etc/apt/keyrings/docker.asc; \
+    . /etc/os-release; \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu ${VERSION_CODENAME} stable" > /etc/apt/sources.list.d/docker.list; \
+    apt-get update; \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+      docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin; \
+    apt-get clean; rm -rf /var/lib/apt/lists/*
 
 # Install the magic wrapper.
 ADD ./wrapdocker /usr/local/bin/wrapdocker


### PR DESCRIPTION
Dockerfile install docker command is outdated and causes issues when running the autograder. This PR fixes the issues by installing docker using the package manager.
