### PR TITLE
Local Docker Image Fix

### DIFF
--- a/vmms/localDocker.py
+++ b/vmms/localDocker.py
@@ -258,7 +258,7 @@ class LocalDocker(object):
         function is a lot of parsing and so can break easily.
         """
         result = set()
-        cmd = "docker images"
+        cmd = "docker images --format 'table {{.Repository}}'"
         o = subprocess.check_output(cmd, shell=True).decode("utf-8")
         o_l = o.split("\n")
         o_l.pop()
@@ -282,7 +282,7 @@ class LocalDocker(object):
             config.Config.MAX_OUTPUT_FILE_SIZE,
         )
         output = subprocess.check_output(
-            cmd, stderr=subprocess.STDOUT, shell=True
+            cmd, stderr=subprocess.STDOUT, shell=True, timeout=30
         ).decode("utf-8")
 
         return output


### PR DESCRIPTION
Tango job hangs indefinitely due because it does not recognize the name of docker images.

This PR implements Bryan Parno's fix.

<img width="679" height="536" alt="Screenshot 2026-01-16 at 2 48 04 PM" src="https://github.com/user-attachments/assets/30cbf9b9-2eab-43f6-a4ab-c5eddd00e5ac" />
