### PR TITLE
Cleanup of Local Docker Images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ env/
 tests/*
 !tests/*.py
 !tests/filesForDockerTest/
+*.pem

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ env/
 # Tests
 tests/*
 !tests/*.py
+!tests/filesForDockerTest/

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ bin
 lib
 include
 pip-selfcheck.json
+env/
 
 # Mac OS X custom attribute files
 .DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,10 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN chmod 1777 /tmp
 
 # Install dependancies
+RUN rm -f /etc/apt/sources.list.d/*passenger* \
+ && apt-get update \
+ && apt-get install -y sqlite3 tzdata shared-mime-info \
+ && rm -rf /var/lib/apt/lists/*
 RUN apt-get update && apt-get install -y \
 	nginx \
 	curl \
@@ -38,7 +42,7 @@ RUN apt-get update && apt-get install -y \
 
 WORKDIR /opt/TangoService/Tango/
 
-# Install Docker
+# Install Docker from Docker Inc. repositories.
 RUN set -eux; \
     apt-get update; \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ca-certificates curl gnupg; \

--- a/config.template.py
+++ b/config.template.py
@@ -40,7 +40,7 @@ class Config(object):
 
     # VMMS to use. Must be set to a VMMS implemented in vmms/ before
     # starting Tango.  Options are: "localDocker", "distDocker",
-    # "tashiSSH", and "ec2SSH"
+    # "tashiSSH", "ec2SSH", "ec2Docker"
     VMMS_NAME = "localDocker"
 
     # Update this to the 'volumes' directory of your Tango installation if
@@ -152,15 +152,10 @@ class Config(object):
     DEFAULT_AMI = ""
     DEFAULT_INST_TYPE = ""
     DEFAULT_SECURITY_GROUP = ""
-    SECURITY_KEY_PATH = ""
+    SECURITY_KEY_PATH = "" # Absolute path to the key on your local machine
     DYNAMIC_SECURITY_KEY_PATH = ""
-    SECURITY_KEY_NAME = ""
+    SECURITY_KEY_NAME = "" # The name of the key pair in AWS (no .pem)
     TANGO_RESERVATION_ID = ""
     INSTANCE_RUNNING = 16  # Status code of a instance that is running
 
     MAX_EC2_VMS = 5  # The maximum number of spot instances allowed at once
-
-    SECURITY_KEY_NAME = "" # The name of the key pair in AWS (no .pem)
-    SECURITY_KEY_PATH = "/path/to/key.pem-ptt" # Absolute path to the key on your local machine
-    
-    PREFIX = "autolab" # Used to name the EC2 instances

--- a/config.template.py
+++ b/config.template.py
@@ -157,3 +157,10 @@ class Config(object):
     SECURITY_KEY_NAME = ""
     TANGO_RESERVATION_ID = ""
     INSTANCE_RUNNING = 16  # Status code of a instance that is running
+
+    MAX_EC2_VMS = 5  # The maximum number of spot instances allowed at once
+
+    SECURITY_KEY_NAME = "" # The name of the key pair in AWS (no .pem)
+    SECURITY_KEY_PATH = "/path/to/key.pem-ptt" # Absolute path to the key on your local machine
+    
+    PREFIX = "autolab" # Used to name the EC2 instances

--- a/jobManager.py
+++ b/jobManager.py
@@ -76,10 +76,15 @@ class JobManager(object):
             try:
                 # if the job is a ec2 vmms job
                 # spin up an ec2 instance for that job
-                if Config.VMMS_NAME == "ec2SSH":
-                    from vmms.ec2SSH import Ec2SSH
-
-                    vmms = Ec2SSH(job.accessKeyId, job.accessKey)
+                if Config.VMMS_NAME == "ec2SSH" or Config.VMMS_NAME == "ec2Docker":
+                    if Config.VMMS_NAME == "ec2SSH":
+                        from vmms.ec2SSH import Ec2SSH
+                        vmms = Ec2SSH(job.accessKeyId, job.accessKey)
+                    elif Config.VMMS_NAME == "ec2Docker":
+                        from vmms.ec2Docker import Ec2Docker
+                        vmms = Ec2Docker(job.accessKeyId, job.accessKey)
+                    else:
+                        raise Exception("Invalid VMMS")
 
                     newVM = copy.deepcopy(job.vm)
                     newVM.id = self._getNextID()

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ cffi==1.17.1
 charset-normalizer==3.4.3
 cryptography==45.0.7
 distlib==0.4.0
-docker==5.0.3
+docker==7.1.0
 filelock==3.16.1
 idna==3.10
 jmespath==1.0.1

--- a/restful_tango/server.py
+++ b/restful_tango/server.py
@@ -151,7 +151,6 @@ class BuildImageHandler(tornado.web.RequestHandler):
             payload = json.loads(self.request.body.decode('utf-8'))
             course_id = payload.get("course_id")
             image_name = payload.get("image_name")
-            tag = payload.get("tag", "latest")
             dockerfile_content = payload.get("dockerfile_content")
 
             if not all([course_id, image_name, dockerfile_content]):
@@ -160,7 +159,7 @@ class BuildImageHandler(tornado.web.RequestHandler):
                 return
 
             # Trigger background build
-            job_id = tangoREST.buildImage(key, course_id, image_name, tag, dockerfile_content)
+            job_id = tangoREST.buildImage(key, course_id, image_name, dockerfile_content)
 
             response = {
                 "statusMsg": "Building image in ECR",

--- a/restful_tango/server.py
+++ b/restful_tango/server.py
@@ -2,6 +2,7 @@ import os
 import sys
 import inspect
 import hashlib
+import json 
 
 import urllib.error
 import urllib.parse
@@ -13,6 +14,7 @@ from restful_tango.tangoREST import TangoREST
 import asyncio
 
 from config import Config
+from vmms import ecrBuilder 
 
 tangoREST = TangoREST()
 
@@ -142,6 +144,40 @@ class BuildHandler(tornado.web.RequestHandler):
         self.tempfile.close()
         self.write(tangoREST.build(key, name, self.request.headers["imageName"]))
 
+class BuildImageHandler(tornado.web.RequestHandler):
+    def post(self, key):
+        """post - Trigger the ECR Docker build."""
+        try:
+            payload = json.loads(self.request.body.decode('utf-8'))
+            course_id = payload.get("course_id")
+            image_name = payload.get("image_name")
+            tag = payload.get("tag", "latest")
+            dockerfile_content = payload.get("dockerfile_content")
+
+            if not all([course_id, image_name, dockerfile_content]):
+                self.set_status(400)
+                self.write({"statusMsg": "Missing required parameters", "statusId": -1})
+                return
+
+            # Trigger background build
+            job_id = ecrBuilder.start_ecr_build(course_id, image_name, tag, dockerfile_content)
+
+            response = {
+                "statusMsg": "Building image in ECR",
+                "statusId": 0,
+                "jobId": job_id
+            }
+            self.write(json.dumps(response))
+            
+        except Exception as e:
+            self.set_status(500)
+            self.write({"statusMsg": f"Server Error: {str(e)}", "statusId": -1})
+
+class BuildStatusHandler(tornado.web.RequestHandler):
+    def get(self, key, jobId):
+        """get - Poll for the status of an ECR build."""
+        status_data = ecrBuilder.get_build_status(jobId)
+        self.write(json.dumps(status_data))
 
 async def main(port: int):
     # Routes
@@ -158,6 +194,8 @@ async def main(port: int):
             (r"/pool/(%s)/" % (SHA1_KEY), PoolHandler),
             (r"/prealloc/(%s)/(%s)/(%s)/" % (SHA1_KEY, IMAGE, NUM), PreallocHandler),
             (r"/build/(%s)/" % (SHA1_KEY), BuildHandler),
+            (r"/build_image/(%s)/" % (SHA1_KEY), BuildImageHandler), 
+            (r"/build_status/(%s)/(%s)/" % (SHA1_KEY, JOBID), BuildStatusHandler), 
         ]
     )
     application.listen(port, max_buffer_size=Config.MAX_INPUT_FILE_SIZE)

--- a/restful_tango/server.py
+++ b/restful_tango/server.py
@@ -164,7 +164,7 @@ class BuildImageHandler(tornado.web.RequestHandler):
 
             response = {
                 "statusMsg": "Building image in ECR",
-                "statusId": 0,
+                "statusId": 1,
                 "jobId": job_id
             }
             self.write(response)
@@ -177,6 +177,12 @@ class BuildStatusHandler(tornado.web.RequestHandler):
     def get(self, key, jobId):
         """get - Poll for the status of an ECR build."""
         status_data = tangoREST.buildStatus(key, job_id=jobId)
+        self.write(status_data)
+
+class AllBuildStatusHandler(tornado.web.RequestHandler):
+    def get(self, key):
+        """get - Poll for the status of an ECR build."""
+        status_data = tangoREST.allBuildStatus(key)
         self.write(status_data)
 
 async def main(port: int):
@@ -196,6 +202,7 @@ async def main(port: int):
             (r"/build/(%s)/" % (SHA1_KEY), BuildHandler),
             (r"/build_image/(%s)/" % (SHA1_KEY), BuildImageHandler), 
             (r"/build_status/(%s)/(%s)/" % (SHA1_KEY, JOBID), BuildStatusHandler), 
+            (r"/all_build_status/(%s)/" % (SHA1_KEY), AllBuildStatusHandler), 
         ]
     )
     application.listen(port, max_buffer_size=Config.MAX_INPUT_FILE_SIZE)

--- a/restful_tango/server.py
+++ b/restful_tango/server.py
@@ -160,14 +160,14 @@ class BuildImageHandler(tornado.web.RequestHandler):
                 return
 
             # Trigger background build
-            job_id = ecrBuilder.start_ecr_build(course_id, image_name, tag, dockerfile_content)
+            job_id = tangoREST.buildImage(key, course_id, image_name, tag, dockerfile_content)
 
             response = {
                 "statusMsg": "Building image in ECR",
                 "statusId": 0,
                 "jobId": job_id
             }
-            self.write(json.dumps(response))
+            self.write(response)
             
         except Exception as e:
             self.set_status(500)
@@ -176,8 +176,8 @@ class BuildImageHandler(tornado.web.RequestHandler):
 class BuildStatusHandler(tornado.web.RequestHandler):
     def get(self, key, jobId):
         """get - Poll for the status of an ECR build."""
-        status_data = ecrBuilder.get_build_status(jobId)
-        self.write(json.dumps(status_data))
+        status_data = tangoREST.buildStatus(key, job_id=jobId)
+        self.write(status_data)
 
 async def main(port: int):
     # Routes

--- a/restful_tango/server.py
+++ b/restful_tango/server.py
@@ -153,14 +153,31 @@ class BuildImageHandler(tornado.web.RequestHandler):
             job_id = payload.get("job_id")
             image_name = payload.get("image_name")
             dockerfile_content = payload.get("dockerfile_content")
+            is_public = payload.get("is_public")
+            base_tag = payload.get("base_tag")
+            base_uri = payload.get("base_uri")
 
-            if not all([course_id, job_id, image_name, dockerfile_content]):
+            if any(x is None for x in [job_id, image_name, dockerfile_content, is_public]):
                 self.set_status(400)
+                print([job_id, image_name, dockerfile_content, is_public, course_id])
                 self.write({"statusMsg": "Missing required parameters", "statusId": -1})
                 return
+            
+            if not is_public and course_id is None:
+                self.set_status(400)
+                self.write({"statusMsg": "Requires course_id if image is private.", "statusId": -1})
+                return
+            
+            if base_tag is not None and base_uri is None:
+                self.set_status(400)
+                self.write({"statusMsg": "Requires the URI to pull from a base docker image", "statusId": -1})
+                return
+            
+            if is_public:
+                course_id = "public"
 
             # Trigger background build
-            job_id = tangoREST.buildImage(key, course_id, job_id, image_name, dockerfile_content)
+            job_id = tangoREST.buildImage(key, course_id, job_id, image_name, dockerfile_content, base_tag, base_uri)
 
             response = {
                 "statusMsg": "Building image in ECR",

--- a/restful_tango/server.py
+++ b/restful_tango/server.py
@@ -150,16 +150,17 @@ class BuildImageHandler(tornado.web.RequestHandler):
         try:
             payload = json.loads(self.request.body.decode('utf-8'))
             course_id = payload.get("course_id")
+            job_id = payload.get("job_id")
             image_name = payload.get("image_name")
             dockerfile_content = payload.get("dockerfile_content")
 
-            if not all([course_id, image_name, dockerfile_content]):
+            if not all([course_id, job_id, image_name, dockerfile_content]):
                 self.set_status(400)
                 self.write({"statusMsg": "Missing required parameters", "statusId": -1})
                 return
 
             # Trigger background build
-            job_id = tangoREST.buildImage(key, course_id, image_name, dockerfile_content)
+            job_id = tangoREST.buildImage(key, course_id, job_id, image_name, dockerfile_content)
 
             response = {
                 "statusMsg": "Building image in ECR",

--- a/restful_tango/tangoREST.py
+++ b/restful_tango/tangoREST.py
@@ -503,12 +503,12 @@ class TangoREST(object):
             os.unlink(tempfile)
             return self.status.wrong_key
         
-    def buildImage(self, key, course_id, image_name, dockerfile_content):
+    def buildImage(self, key, course_id, job_id, image_name, dockerfile_content):
         self.log.debug("Received docker image build request(%s)" % (key))
         if self.validateKey(key):
             from vmms.ecrBuilder import start_ecr_build
             self.log.info("Starting docker image build %s" % image_name)
-            return start_ecr_build(course_id, image_name, dockerfile_content)
+            return start_ecr_build(course_id, job_id, image_name, dockerfile_content)
         else:
             self.log.info("Key not recognized: %s" % key)
             return self.status.wrong_key

--- a/restful_tango/tangoREST.py
+++ b/restful_tango/tangoREST.py
@@ -502,3 +502,22 @@ class TangoREST(object):
             self.log.info("Key not recognized: %s" % key)
             os.unlink(tempfile)
             return self.status.wrong_key
+        
+    def buildImage(self, key, course_id, image_name, tag, dockerfile_content):
+        self.log.debug("Received docker image build request(%s)" % (key))
+        if self.validateKey(key):
+            from vmms.ecrBuilder import start_ecr_build
+            self.log.info("Starting docker image build %s" % image_name)
+            return start_ecr_build(course_id, image_name, tag, dockerfile_content)
+        else:
+            self.log.info("Key not recognized: %s" % key)
+            return self.status.wrong_key
+        
+    def buildStatus(self, key, job_id):
+        self.log.debug("Received docker image status request(%s)" % (key))
+        if self.validateKey(key):
+            from vmms.ecrBuilder import get_build_status
+            return get_build_status(job_id)
+        else:
+            self.log.info("Key not recognized: %s" % key)
+            return self.status.wrong_key

--- a/restful_tango/tangoREST.py
+++ b/restful_tango/tangoREST.py
@@ -521,3 +521,12 @@ class TangoREST(object):
         else:
             self.log.info("Key not recognized: %s" % key)
             return self.status.wrong_key
+        
+    def allBuildStatus(self, key):
+        self.log.debug("Received all docker image status request(%s)" % (key))
+        if self.validateKey(key):
+            from vmms.ecrBuilder import get_all_build_status
+            return get_all_build_status()
+        else:
+            self.log.info("Key not recognized: %s" % key)
+            return self.status.wrong_key

--- a/restful_tango/tangoREST.py
+++ b/restful_tango/tangoREST.py
@@ -503,12 +503,12 @@ class TangoREST(object):
             os.unlink(tempfile)
             return self.status.wrong_key
         
-    def buildImage(self, key, course_id, image_name, tag, dockerfile_content):
+    def buildImage(self, key, course_id, image_name, dockerfile_content):
         self.log.debug("Received docker image build request(%s)" % (key))
         if self.validateKey(key):
             from vmms.ecrBuilder import start_ecr_build
             self.log.info("Starting docker image build %s" % image_name)
-            return start_ecr_build(course_id, image_name, tag, dockerfile_content)
+            return start_ecr_build(course_id, image_name, dockerfile_content)
         else:
             self.log.info("Key not recognized: %s" % key)
             return self.status.wrong_key

--- a/restful_tango/tangoREST.py
+++ b/restful_tango/tangoREST.py
@@ -503,12 +503,12 @@ class TangoREST(object):
             os.unlink(tempfile)
             return self.status.wrong_key
         
-    def buildImage(self, key, course_id, job_id, image_name, dockerfile_content):
+    def buildImage(self, key, course_id, job_id, image_name, dockerfile_content, base_tag, base_uri):
         self.log.debug("Received docker image build request(%s)" % (key))
         if self.validateKey(key):
             from vmms.ecrBuilder import start_ecr_build
             self.log.info("Starting docker image build %s" % image_name)
-            return start_ecr_build(course_id, job_id, image_name, dockerfile_content)
+            return start_ecr_build(course_id, job_id, image_name, dockerfile_content, base_tag, base_uri)
         else:
             self.log.info("Key not recognized: %s" % key)
             return self.status.wrong_key

--- a/restful_tango/tangoREST.py
+++ b/restful_tango/tangoREST.py
@@ -228,7 +228,7 @@ class TangoREST(object):
         """convertTangoJobObj - Converts a TangoJob object into a dictionary"""
         job = dict()
         # Convert scalar attribtues first
-        job["retries"] = tangoJobObj.retries
+        # job["retries"] = tangoJobObj.retries
         job["outputFile"] = tangoJobObj.outputFile
         job["name"] = tangoJobObj.name
         job["notifyURL"] = tangoJobObj.notifyURL
@@ -530,3 +530,4 @@ class TangoREST(object):
         else:
             self.log.info("Key not recognized: %s" % key)
             return self.status.wrong_key
+            self.log.error("Validation failed %s" % (key))

--- a/restful_tango/tangoREST.py
+++ b/restful_tango/tangoREST.py
@@ -159,7 +159,7 @@ class TangoREST(object):
             )
             input.append(handinfile)
 
-        ec2_vmms = Config.VMMS_NAME == "ec2SSH"
+        ec2_vmms = Config.VMMS_NAME == "ec2SSH" or Config.VMMS_NAME == "ec2Docker"
 
         stopBefore = ""
         if "stopBefore" in jobObj:

--- a/tango.py
+++ b/tango.py
@@ -74,6 +74,10 @@ class TangoServer(object):
             from vmms.distDocker import DistDocker
 
             vmms = DistDocker()
+        elif Config.VMMS_NAME == "ec2Docker":
+            from vmms.ec2Docker import Ec2Docker
+
+            vmms = Ec2Docker()
 
         self.preallocator: Preallocator = Preallocator({Config.VMMS_NAME: vmms})
         self.jobQueue: JobQueue = JobQueue(self.preallocator)

--- a/tests/filesForDockerTest/Dockerfile
+++ b/tests/filesForDockerTest/Dockerfile
@@ -1,0 +1,16 @@
+FROM ubuntu:24.04
+
+# Install compilation tools and the 'time' utility Tango uses
+RUN apt-get update && apt-get install -y build-essential time
+
+RUN useradd -m autolab
+RUN useradd -m autograde
+
+# Copy local autodriver source code into the container
+COPY . /opt/autodriver
+
+# Compile the autodriver directly, bypassing the legacy Makefile
+RUN cd /opt/autodriver && gcc -W -Wall -Wextra -o /usr/bin/autodriver autodriver.c
+
+RUN chown root:root /usr/bin/autodriver
+RUN chmod +s /usr/bin/autodriver

--- a/tests/filesForDockerTest/Makefile
+++ b/tests/filesForDockerTest/Makefile
@@ -1,0 +1,3 @@
+all:
+	gcc hello.c -o hello
+	./hello

--- a/tests/filesForDockerTest/expected_feedback.txt
+++ b/tests/filesForDockerTest/expected_feedback.txt
@@ -1,0 +1,4 @@
+Autodriver: Job exited with status 0
+gcc hello.c -o hello
+./hello
+Grading complete! 100/100

--- a/tests/filesForDockerTest/hello.c
+++ b/tests/filesForDockerTest/hello.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+
+int main() {
+    printf("Grading complete! 100/100\n");
+    return 0;
+}

--- a/tests/testDockerVMMSLifecycle.py
+++ b/tests/testDockerVMMSLifecycle.py
@@ -1,0 +1,68 @@
+import time
+from tangoObjects import TangoMachine, InputFile
+from vmms.ec2Docker import Ec2Docker
+
+def run_lifecycle_test():
+    print("🚀 Initializing Ec2Docker VMMS Integration Test...")
+    vmms = Ec2Docker()
+    
+    # Mock the Autolab Machine Object
+    vm = TangoMachine()
+    vm.id = 999
+    vm.name = "test-ec2docker-instance"
+    
+    # REPLACE THIS with an actual URI from ECR dashboard
+    vm.image = "992382617910.dkr.ecr.us-east-2.amazonaws.com/15-122-env:real-autograder" 
+
+    try:
+        # Provisioning
+        print(f"\n[1/5] Spinning up Spot instance for {vm.name}...")
+        init_status = vmms.initializeVM(vm)
+        if init_status != 0:
+            print("❌ Failed to initialize VM. Check AWS credentials and base AMI.")
+            return
+        print(f"✅ EC2 Provisioned! Instance ID: {vm.instance_id}")
+
+        # Initialization
+        print("\n[2/5] Waiting for OS and SSH to boot (approx 60 seconds)...")
+        wait_status = vmms.waitVM(vm, max_secs=300)
+        if wait_status != 0:
+            print("❌ VM failed to boot or SSH timed out.")
+            return
+        print("✅ SSH is responsive!")
+
+        # File Transfer (copyIn)
+        print("\n[3/5] Copying test payload (hello.c and Makefile) to EC2...")
+        payload_files = [
+            InputFile(localFile="hello.c", destFile="hello.c"),
+            InputFile(localFile="Makefile", destFile="Makefile")
+        ]
+        
+        copy_status = vmms.copyIn(vm, payload_files)
+        if copy_status != 0:
+            print("❌ Failed to SCP files.")
+            return
+        print("✅ Files copied successfully!")
+
+        # Docker Execution
+        print(f"\n[4/5] Pulling {vm.image} from ECR and executing...")
+        run_status = vmms.runJob(vm, runTimeout=60, maxOutputFileSize=1024, disableNetwork=True)
+        print(f"✅ Execution returned status code: {run_status}")
+
+        # Retrieval (copyOut)
+        print("\n[5/5] Retrieving feedback...")
+        copyout_status = vmms.copyOut(vm, "local_feedback.txt")
+        if copyout_status == 0:
+            print("✅ Feedback successfully downloaded to local_feedback.txt")
+        else:
+            print("⚠️ Feedback retrieval failed (container may have crashed).")
+
+    finally:
+        # Teardown
+        if vm.instance_id:
+            print("\n🧹 Tearing down EC2 instance...")
+            vmms.destroyVM(vm)
+            print("✅ VM Terminated. End-to-End Test complete.")
+
+if __name__ == "__main__":
+    run_lifecycle_test()

--- a/tests/test_ECR.py
+++ b/tests/test_ECR.py
@@ -1,0 +1,112 @@
+import requests
+import time
+import sys
+
+BASE_URL = "http://localhost:3000"
+API_KEY = "test"
+
+def run_build_and_poll(test_name, payload, expected_success):
+    print(f"\n[{test_name}] Initiating test...")
+    build_url = f"{BASE_URL}/build_image/{API_KEY}/"
+    
+    try:
+        # Trigger the POST request
+        response = requests.post(build_url, json=payload)
+        response_data = response.json()
+        job_id = response_data.get("jobId")
+        
+        if not job_id:
+            print(f"❌ [{test_name}] FAILED: No jobId returned.")
+            return False
+            
+        print(f"⏳ [{test_name}] Job {job_id} started. Polling...")
+        
+        # Poll the GET request
+        status_url = f"{BASE_URL}/build_status/{API_KEY}/{job_id}/"
+        
+        # Timeout safety (e.g., 2 minutes maximum per build)
+        timeout = time.time() + 120 
+        
+        while time.time() < timeout:
+            status_res = requests.get(status_url)
+            status_data = status_res.json()
+            
+            status_id = status_data.get("statusId")
+            msg = status_data.get("statusMsg")
+            
+            if status_id == 0:
+                if expected_success:
+                    print(f"✅ [{test_name}] PASSED! Image built: {status_data.get('ecr_image_uri')}")
+                    return True
+                else:
+                    print(f"❌ [{test_name}] FAILED: Expected failure, but it succeeded!")
+                    return False
+                    
+            elif status_id < 0:
+                if not expected_success:
+                    print(f"✅ [{test_name}] PASSED! Caught expected failure: {msg}")
+                    return True
+                else:
+                    print(f"❌ [{test_name}] FAILED: Expected success, but got error: {msg}")
+                    return False
+                    
+            time.sleep(2)
+            
+        print(f"❌ [{test_name}] FAILED: Polling timed out.")
+        return False
+
+    except requests.exceptions.ConnectionError:
+        print("❌ FAILED: Could not connect to Tango. Is server.py running?")
+        sys.exit(1)
+
+def main():
+    print("🚀 Starting Autolab ECR Integration Test Suite...\n")
+    
+    tests_passed = 0
+    total_tests = 3
+
+    # TEST 1: Unique Hash / New Tag
+    # Proves ECR creates a unique layer digest when the Dockerfile changes
+    payload_1 = {
+        "course_id": "15122",
+        "image_name": "15-122-env",
+        "tag": "hw3",
+        "dockerfile_content": "FROM alpine:latest\nRUN echo \"Different assignment setup\""
+    }
+    if run_build_and_poll("TEST 1: Unique Image Hash", payload_1, expected_success=True):
+        tests_passed += 1
+
+    # TEST 2: JIT Provisioner
+    # Proves our try/except block correctly creates a brand new course repo on the fly
+    payload_2 = {
+        "course_id": "15213",
+        "image_name": "15-213-env",
+        "tag": "latest",
+        "dockerfile_content": "FROM alpine:latest\nRUN echo \"Welcome to Systems\""
+    }
+    if run_build_and_poll("TEST 2: JIT Repo Provisioning", payload_2, expected_success=True):
+        tests_passed += 1
+
+    # TEST 3: Deliberate Build Failure
+    # Proves a typo from a professor won't crash Tango, and safely returns statusId -1
+    payload_3 = {
+        "course_id": "15122",
+        "image_name": "15-122-env",
+        "tag": "bad-dockerfile",
+        "dockerfile_content": "FRM alpine:latest\nRUN echo \"This should crash\""
+    }
+    if run_build_and_poll("TEST 3: Syntax Error Handling", payload_3, expected_success=False):
+        tests_passed += 1
+
+    # Final Report
+    print("\n" + "="*40)
+    print(f"🏁 TEST RUN COMPLETE: {tests_passed}/{total_tests} Passed")
+    print("="*40)
+    
+    if tests_passed == total_tests:
+        print("🎉 All test Passed!")
+    else:
+        print("⚠️ Some tests failed. Check the logs above.")
+
+if __name__ == "__main__":
+    main()

--- a/vmms/ec2Docker.py
+++ b/vmms/ec2Docker.py
@@ -487,7 +487,7 @@ class Ec2Docker(VMMSInterface):
         runcmd = (
             f"aws ecr get-login-password --region {region} | "
             f"docker login --username AWS --password-stdin {registry_url} && "
-            f"docker run --rm {network_flag}-v /home/%s/autolab:/home/mount -w /home {vm.image} "
+            f"docker run --name autograder --rm {network_flag}-v /home/%s/autolab:/home/mount -w /home {vm.image} "
             "sh -c \"cd /home && mkdir -p output && chown autolab:autolab output && "
             "cp -a mount/. autolab/ && chown -R autolab:autolab autolab/ && "
             "su autolab -c \\\"autodriver "
@@ -587,6 +587,6 @@ class Ec2Docker(VMMSInterface):
 
     def getPartialOutput(self, vm):
         domain_name = self.domainName(vm)
-        runcmd = "head -c %s autolab/feedback" % (config.Config.MAX_OUTPUT_FILE_SIZE)
+        runcmd = "docker exec autograder head -c %s autograde/output.log" % (config.Config.MAX_OUTPUT_FILE_SIZE)
         sshcmd = (["ssh"] + self.ssh_flags + ["%s@%s" % (self.ec2User, domain_name), runcmd])
         return subprocess.check_output(sshcmd, stderr=subprocess.STDOUT).decode("utf-8")

--- a/vmms/ec2Docker.py
+++ b/vmms/ec2Docker.py
@@ -5,6 +5,7 @@
 import logging
 import os
 import re
+import stat
 import subprocess
 import threading
 import time
@@ -119,6 +120,12 @@ class Ec2Docker(VMMSInterface):
     _SSH_FLAGS = [
         "-i", config.Config.SECURITY_KEY_PATH,
         "-o", "StrictHostKeyChecking no",
+        "-o", "UserKnownHostsFile=/dev/null",
+        "-o", "GlobalKnownHostsFile=/dev/null",
+        "-o", "BatchMode yes",
+        "-o", "IdentitiesOnly yes",
+        "-o", "PreferredAuthentications publickey",
+        "-o", "ConnectTimeout 5",
         "-o", "GSSAPIAuthentication no",
     ]
 
@@ -134,10 +141,55 @@ class Ec2Docker(VMMSInterface):
         """Releases the VM sempahore"""
         Ec2Docker._vm_semaphore.release()
 
+    @staticmethod
+    def _validate_ec2_runtime_config() -> str:
+        """Validate required EC2 configuration and return normalized key path."""
+        missing = []
+
+        if not str(config.Config.EC2_REGION).strip():
+            missing.append("EC2_REGION")
+        if not str(config.Config.EC2_USER_NAME).strip():
+            missing.append("EC2_USER_NAME")
+        if not str(config.Config.SECURITY_KEY_PATH).strip():
+            missing.append("SECURITY_KEY_PATH")
+
+        if missing:
+            raise ValueError(
+                "Missing required EC2 configuration: %s"
+                % ", ".join(missing)
+            )
+
+        key_path = os.path.expanduser(str(config.Config.SECURITY_KEY_PATH).strip())
+        if not os.path.isfile(key_path):
+            raise ValueError(
+                "Invalid SECURITY_KEY_PATH (file does not exist): %s" % key_path
+            )
+        if not os.access(key_path, os.R_OK):
+            raise ValueError(
+                "Invalid SECURITY_KEY_PATH (file is not readable): %s" % key_path
+            )
+
+        key_mode = stat.S_IMODE(os.stat(key_path).st_mode)
+        if key_mode & 0o077:
+            # Try to auto-fix common container mount permission issue.
+            try:
+                os.chmod(key_path, 0o600)
+            except OSError:
+                pass
+
+            key_mode = stat.S_IMODE(os.stat(key_path).st_mode)
+            if key_mode & 0o077:
+                raise ValueError(
+                    "Invalid SECURITY_KEY_PATH permissions for private key %s (mode %o). "
+                    "Expected chmod 600 (or stricter)." % (key_path, key_mode)
+                )
+
+        return key_path
+
     def refresh_ecr_images(self):
         self.ecrImages = {}
         try:
-            ecrClient = boto3.client("ecr", config.Config.EC2_REGION)
+            ecrClient = boto3.client("ecr", self.ec2Region)
 
             for repo_page in ecrClient.get_paginator("describe_repositories").paginate():
                 for repo in repo_page["repositories"]:
@@ -165,6 +217,7 @@ class Ec2Docker(VMMSInterface):
         """
         # do not do anything until we acquire a vm semaphore
         Ec2Docker.acquire_vm_semaphore()
+        validated_key_path = Ec2Docker._validate_ec2_runtime_config()
 
         self.appName = os.path.basename(__file__).strip(".py")
         # Setup logger
@@ -174,20 +227,22 @@ class Ec2Docker(VMMSInterface):
         # initialize EC2 USER
         # PDL gets a ec2user in the parameter, just use the default
         # user for now
-        self.ssh_flags = Ec2Docker._SSH_FLAGS
-        self.ec2User = config.Config.EC2_USER_NAME
+        self.ssh_flags = Ec2Docker._SSH_FLAGS.copy()
+        self.ssh_flags[1] = validated_key_path
+        self.ec2User = str(config.Config.EC2_USER_NAME).strip()
+        self.ec2Region = str(config.Config.EC2_REGION).strip()
         self.useDefaultKeyPair = True
 
         if self.useDefaultKeyPair:
             self.key_pair_name: str = config.Config.SECURITY_KEY_NAME
-            self.key_pair_path: str = config.Config.SECURITY_KEY_PATH
+            self.key_pair_path: str = validated_key_path
         else:
             raise
 
         self.img2ami = {} 
         try:
-            self.boto3resource: EC2ServiceResource = boto3.resource("ec2", config.Config.EC2_REGION)
-            self.boto3client = boto3.client("ec2", config.Config.EC2_REGION)
+            self.boto3resource: EC2ServiceResource = boto3.resource("ec2", self.ec2Region)
+            self.boto3client = boto3.client("ec2", self.ec2Region)
             images = self.boto3resource.images.filter(Owners=["self"])
         except Exception as e:
             self.log.error("Ec2Docker failed initialization: %s" % (e))
@@ -426,7 +481,7 @@ class Ec2Docker(VMMSInterface):
         
         # Parse the ECR Registry domain from the provided image URI
         registry_url = vm.image.split('/')[0] if '/' in vm.image else ""
-        region = config.Config.EC2_REGION
+        region = self.ec2Region
         
         # ECR Auth -> Docker Run
         runcmd = (
@@ -469,7 +524,7 @@ class Ec2Docker(VMMSInterface):
             except subprocess.CalledProcessError: pass
 
         return timeout(
-            ["scp"] + self.ssh_flags + ["%s@%s:autolab/feedback" % (config.Config.EC2_USER_NAME, domain_name), destFile],
+            ["scp"] + self.ssh_flags + ["%s@%s:autolab/feedback" % (self.ec2User, domain_name), destFile],
             config.Config.COPYOUT_TIMEOUT,
         )
 

--- a/vmms/ec2Docker.py
+++ b/vmms/ec2Docker.py
@@ -1,0 +1,418 @@
+#
+# ec2Docker.py - Implements the Tango VMMS interface to run Tango Docker jobs on Amazon EC2.
+#
+
+import logging
+import os
+import re
+import subprocess
+import threading
+import time
+
+import backoff
+import boto3
+from botocore.exceptions import ClientError
+
+import config
+from tangoObjects import TangoMachine
+from typing import Optional, Literal, List, Sequence
+from mypy_boto3_ec2 import EC2ServiceResource
+from mypy_boto3_ec2.service_resource import Instance
+from mypy_boto3_ec2.type_defs import FilterTypeDef
+
+from vmms.interface import VMMSInterface
+
+# Suppress verbose boto logging
+logging.getLogger("boto3").setLevel(logging.CRITICAL)
+logging.getLogger("botocore").setLevel(logging.CRITICAL)
+logging.getLogger("urllib3.connectionpool").setLevel(logging.CRITICAL)
+
+
+def timeout(command, time_out=1):
+    p = subprocess.Popen(command, stdout=open("/dev/null", "w"), stderr=subprocess.STDOUT)
+    t = 0.0
+    while t < time_out and p.poll() is None:
+        time.sleep(config.Config.TIMER_POLL_INTERVAL)
+        t += config.Config.TIMER_POLL_INTERVAL
+    if t >= time_out:
+        print("ERROR: timeout trying ", command)
+    if p.poll() is None:
+        try: os.kill(p.pid, 9)
+        except OSError: pass
+        returncode = -1
+    else:
+        returncode = p.poll()
+    return returncode
+
+
+def timeout_with_retries(command, time_out=1, retries=3, retry_delay=2):
+    for attempt in range(retries + 1):
+        p = subprocess.Popen(command, stdout=open("/dev/null", "w"), stderr=subprocess.STDOUT)
+        t = 0.0
+        while t < time_out and p.poll() is None:
+            time.sleep(config.Config.TIMER_POLL_INTERVAL)
+            t += config.Config.TIMER_POLL_INTERVAL
+        if t >= time_out:
+            print("ERROR: timeout trying ", command)
+
+        if p.poll() is None:
+            try: os.kill(p.pid, 9)
+            except OSError: pass
+            returncode = -1
+        else:
+            returncode = p.poll()
+
+        if returncode == -1:
+            if attempt < retries:
+                print(f"Retrying in {retry_delay} seconds...")
+                time.sleep(retry_delay)
+            else:
+                print("All retries exhausted.")
+                return -1
+        else:
+            return returncode
+
+
+@backoff.on_exception(backoff.expo, ClientError, max_tries=3, jitter=None)
+def try_load_instance(newInstance):
+    newInstance.load()
+
+
+class ec2CallError(Exception):
+    pass
+
+
+class Ec2Docker(VMMSInterface):
+    _SSH_FLAGS = [
+        "-i", config.Config.SECURITY_KEY_PATH,
+        "-o", "StrictHostKeyChecking no",
+        "-o", "GSSAPIAuthentication no",
+    ]
+
+    _vm_semaphore = threading.Semaphore(config.Config.MAX_EC2_VMS)
+
+    @staticmethod
+    def acquire_vm_semaphore():
+        """Blocks until a VM is available to limit system load."""
+        Ec2Docker._vm_semaphore.acquire()
+
+    @staticmethod
+    def release_vm_semaphore():
+        """Releases the VM semaphore."""
+        Ec2Docker._vm_semaphore.release()
+
+    def __init__(self, accessKeyId=None, accessKey=None):
+        Ec2Docker.acquire_vm_semaphore()
+
+        self.appName = os.path.basename(__file__).strip(".py")
+        self.log = logging.getLogger("Ec2Docker-" + str(os.getpid()))
+        self.log.info("init Ec2Docker in program %s" % (self.appName))
+
+        self.ssh_flags = Ec2Docker._SSH_FLAGS
+        self.ec2User = config.Config.EC2_USER_NAME
+        self.useDefaultKeyPair = True
+
+        if self.useDefaultKeyPair:
+            self.key_pair_name: str = config.Config.SECURITY_KEY_NAME
+            self.key_pair_path: str = config.Config.SECURITY_KEY_PATH
+        else:
+            raise
+
+        self.img2ami = {} 
+        self.images = []
+        try:
+            self.boto3resource: EC2ServiceResource = boto3.resource("ec2", config.Config.EC2_REGION)
+            self.boto3client = boto3.client("ec2", config.Config.EC2_REGION)
+            images = self.boto3resource.images.filter(Owners=["self"])
+        except Exception as e:
+            self.log.error("Ec2Docker failed initialization: %s" % (e))
+            raise
+
+        for image in images:
+            if image.tags:
+                for tag in image.tags:
+                    if tag["Key"] == "Name" and tag["Value"]:
+                        if tag["Value"] in self.img2ami:
+                            self.log.info("Ignore %s for duplicate name tag %s" % (image.id, tag["Value"]))
+                        else:
+                            self.img2ami[tag["Value"]] = image
+                            self.log.info("Found image: %s with name tag %s" % (image.id, tag["Value"]))
+
+        imageAMIs = [item.id for item in images]
+        taggedAMIs = [self.img2ami[key].id for key in self.img2ami]
+        ignoredAMIs = list(set(imageAMIs) - set(taggedAMIs))
+
+        if len(ignoredAMIs) > 0:
+            self.log.info("Ignored images %s for lack of or ill-formed name tag" % str(ignoredAMIs))
+
+    def instanceName(self, id, name):
+        return "%s-%d-%s" % (config.Config.PREFIX, id, name)
+
+    def keyPairName(self, id, name):
+        return "%s-%d-%s" % (config.Config.PREFIX, id, name)
+
+    def domainName(self, vm):
+        return vm.domain_name
+
+    def tangoMachineToEC2Instance(self, vm: TangoMachine) -> dict:
+        """Returns instance type and base AMI. Defers to a universal Docker base image."""
+        ec2instance = dict()
+        if vm.instance_type is not None:
+            ec2instance["instance_type"] = vm.instance_type
+        else:
+            ec2instance["instance_type"] = config.Config.DEFAULT_INST_TYPE
+
+        # Use universal base AMI for all Docker executions
+        ec2instance["ami"] = self.img2ami["autolab-docker-base"].id
+        self.log.info("tangoMachineToEC2Instance: %s" % str(ec2instance))
+        return ec2instance
+
+    def createKeyPair(self):
+        raise
+
+    def deleteKeyPair(self):
+        raise
+
+    def createSecurityGroup(self):
+        try:
+            response = self.boto3client.describe_security_groups(
+                Filters=[{"Name": "group-name", "Values": [config.Config.DEFAULT_SECURITY_GROUP]}]
+            )
+            if response["SecurityGroups"]: return
+        except Exception as e:
+            self.log.debug("ERROR checking for existing security group: %s", e)
+
+        try:
+            response = self.boto3resource.create_security_group(
+                GroupName=config.Config.DEFAULT_SECURITY_GROUP,
+                Description="Autolab security group - allowing all traffic",
+            )
+            self.boto3resource.authorize_security_group_ingress(GroupId=response["GroupId"])
+        except Exception as e:
+            self.log.debug("ERROR in creating security group: %s", e)
+
+    def initializeVM(self, vm: TangoMachine) -> Literal[0, -1]:
+        """Provisions a new Spot Instance and attaches the ECR Role."""
+        newInstance: Optional[Instance] = None
+        try:
+            instanceName = self.instanceName(vm.id, vm.name)
+            ec2instance = self.tangoMachineToEC2Instance(vm)
+            self.log.debug("instanceName: %s" % instanceName)
+            self.createSecurityGroup()
+
+            reservation: List[Instance] = self.boto3resource.create_instances(
+                ImageId=ec2instance["ami"],
+                KeyName=self.key_pair_name,
+                SecurityGroups=[config.Config.DEFAULT_SECURITY_GROUP],
+                InstanceType=ec2instance["instance_type"],
+                IamInstanceProfile={'Name': 'AutolabEC2ECRRole'}, # Grants ECR access
+                MaxCount=1,
+                MinCount=1,
+                InstanceMarketOptions={
+                    "MarketType": "spot",
+                    "SpotOptions": {
+                        "SpotInstanceType": "one-time",
+                        "InstanceInterruptionBehavior": "terminate"
+                    }
+                },
+            )
+
+            time.sleep(config.Config.TIMER_POLL_INTERVAL)
+            newInstance = reservation[0]
+            if not newInstance:
+                raise ValueError("Cannot find new instance for %s" % vm.name)
+
+            start_time = time.time()
+            while True:
+                filters: Sequence[FilterTypeDef] = [{"Name": "instance-state-name", "Values": ["running"]}]
+                instances = self.boto3resource.instances.filter(Filters=filters)
+                instanceRunning = False
+
+                try_load_instance(newInstance)
+                for inst in instances.filter(InstanceIds=[newInstance.id]):
+                    self.log.debug("VM %s %s: is running" % (vm.name, newInstance.id))
+                    instanceRunning = True
+
+                if instanceRunning: break
+
+                if time.time() - start_time > config.Config.INITIALIZEVM_TIMEOUT:
+                    raise ValueError("VM %s %s: timeout" % (vm.name, newInstance.id))
+                time.sleep(config.Config.TIMER_POLL_INTERVAL)
+
+            self.boto3resource.create_tags(
+                Resources=[newInstance.id], Tags=[{"Key": "Name", "Value": vm.name}],
+            )
+
+            vm.domain_name = newInstance.public_ip_address
+            vm.instance_id = newInstance.id
+            return 0
+
+        except Exception as e:
+            self.log.debug("initializeVM Failed: %s" % e)
+            if newInstance is not None:
+                try: self.boto3resource.instances.filter(InstanceIds=[newInstance.id]).terminate()
+                except Exception as e:
+                    self.log.error("Exception handling failed for %s: %s" % (vm.name, e))
+                    return -1
+            return -1
+
+    def waitVM(self, vm, max_secs) -> Literal[0, -1]:
+        """Polls the instance until network and SSH drivers are responsive."""
+        self.log.info("WaitVM: %s %s" % (vm.name, vm.instance_id))
+        if not self.existsVM(vm): return -1
+            
+        instance_down = 1
+        start_time = time.time()
+        domain_name = self.domainName(vm)
+        
+        while instance_down:
+            instance_down = subprocess.call(
+                "ping -c 1 %s" % (domain_name), shell=True,
+                stdout=open("/dev/null", "w"), stderr=subprocess.STDOUT,
+            )
+            if instance_down:
+                time.sleep(config.Config.TIMER_POLL_INTERVAL)
+                if (time.time() - start_time) > max_secs: return -1
+
+        while True:
+            elapsed_secs = time.time() - start_time
+            if elapsed_secs > max_secs: return -1
+            ret = timeout(
+                ["ssh"] + self.ssh_flags + ["%s@%s" % (self.ec2User, domain_name), "(:)"],
+                max_secs - elapsed_secs,
+            )
+            if (ret != -1) and (ret != 255): return 0
+            time.sleep(config.Config.TIMER_POLL_INTERVAL)
+
+    def copyIn(self, vm, inputFiles, job_id=None):
+        """Creates the staging directory and securely copies grading files to EC2."""
+        self.log.info("copyIn %s - writing files" % self.instanceName(vm.id, vm.name))
+        domain_name = self.domainName(vm)
+
+        subprocess.run(
+            ["ssh"] + self.ssh_flags + ["%s@%s" % (self.ec2User, domain_name), "(mkdir -p autolab && chmod 775 autolab)"],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
+        )
+
+        for file in inputFiles:
+            ret = timeout_with_retries(
+                ["scp"] + self.ssh_flags + [file.localFile, "%s@%s:~/autolab/%s" % (self.ec2User, domain_name, file.destFile)],
+                config.Config.COPYIN_TIMEOUT,
+            )
+            if ret != 0: return ret
+        return 0
+
+    def runJob(self, vm, runTimeout, maxOutputFileSize, disableNetwork):
+        """Authenticates with ECR, pulls the requested course image, and executes the grader."""
+        domain_name = self.domainName(vm)
+        self.log.debug("runJob: Running Docker job on VM %s" % self.instanceName(vm.id, vm.name))
+        
+        network_flag = "--network none " if disableNetwork else ""
+        
+        # Parse the ECR Registry domain from the provided image URI
+        registry_url = vm.image.split('/')[0] if '/' in vm.image else ""
+        region = config.Config.EC2_REGION
+        
+        # ECR Auth -> Docker Run
+        runcmd = (
+            f"aws ecr get-login-password --region {region} | "
+            f"docker login --username AWS --password-stdin {registry_url} && "
+            f"docker run --rm {network_flag}-v /home/%s/autolab:/home/mount -w /home {vm.image} "
+            "sh -c \"mkdir -p output && chown autolab:autolab output && "
+            "cp -a mount/. autolab/ && chown -R autolab:autolab autolab/ && "
+            "su autolab -c \\\"/usr/bin/time --output=output/time.out autodriver "
+            "-u %d -f %d -t %d -o %d autolab > output/feedback 2>&1\\\" ; "
+            "cp output/feedback mount/ ; cp output/time.out mount/\""
+            % (
+                self.ec2User,
+                config.Config.VM_ULIMIT_USER_PROC,
+                config.Config.VM_ULIMIT_FILE_SIZE,
+                runTimeout,
+                maxOutputFileSize,
+            )
+        )
+
+        ret = timeout(["ssh"] + self.ssh_flags + ["%s@%s" % (self.ec2User, domain_name), runcmd], runTimeout * 2)
+        return ret
+
+    def copyOut(self, vm, destFile):
+        """Retrieves the completed feedback log back to the Tango host."""
+        domain_name = self.domainName(vm)
+        if config.Config.LOG_TIMING:
+            try:
+                no_file = re.compile("No such file or directory")
+                time_info = (
+                    subprocess.check_output(["ssh"] + self.ssh_flags + ["%s@%s" % (self.ec2User, domain_name), "cat autolab/time.out"])
+                    .decode("utf-8").rstrip("\n")
+                )
+                if not no_file.match(time_info):
+                    time_info = re.sub("\n", " ", time_info, count=1)
+                    self.log.info("Timing (%s): %s" % (domain_name, time_info))
+            except subprocess.CalledProcessError: pass
+
+        return timeout(
+            ["scp"] + self.ssh_flags + ["%s@%s:autolab/feedback" % (config.Config.EC2_USER_NAME, domain_name), destFile],
+            config.Config.COPYOUT_TIMEOUT,
+        )
+
+    def destroyVM(self, vm):
+        """Terminates the EC2 instance to preserve costs."""
+        try:
+            instances = self.boto3resource.instances.filter(InstanceIds=[vm.instance_id])
+            if (hasattr(config.Config, "KEEP_VM_AFTER_FAILURE") and config.Config.KEEP_VM_AFTER_FAILURE and vm.keep_for_debugging):
+                tag = self.boto3resource.Tag(vm.instance_id, "Name", vm.name)
+                if tag: tag.delete()
+                self.boto3resource.create_tags(
+                    Resources=[vm.instance_id],
+                    Tags=[{"Key": "Name", "Value": "failed-" + vm.name}, {"Key": "Notes", "Value": vm.notes}],
+                )
+                return
+            instances.terminate()
+        except Exception as e:
+            self.log.error("destroyVM failed: %s for vm %s" % (e, vm.instance_id))
+        Ec2Docker.release_vm_semaphore()
+
+    def safeDestroyVM(self, vm):
+        return self.destroyVM(vm)
+
+    def getVMs(self):
+        try:
+            vms = list()
+            filters = [{"Name": "instance-state-name", "Values": ["running", "pending"]}]
+            instances = self.boto3resource.instances.filter(Filters=filters)
+            for instance in instances:
+                vm = TangoMachine()
+                vm.instance_id = instance.id
+                vm.domain_name = None
+                vm.id = None
+                instName = self.getTag(instance.tags, "Name")
+                if not (instName and re.match("%s-" % config.Config.PREFIX, instName)): continue
+                vm.name = instName
+                vm.id = int(instName.split("-")[1])
+                vm.pool = instName.split("-")[2]
+                if instance.public_ip_address: vm.domain_name = instance.public_ip_address
+                vms.append(vm)
+        except Exception: pass
+        return vms
+
+    def existsVM(self, vm):
+        filters = [{"Name": "instance-state-name", "Values": ["running"]}]
+        instances = self.boto3resource.instances.filter(Filters=filters)
+        for instance in instances:
+            if instance.instance_id == vm.instance_id: return True
+        return False
+
+    def getImages(self):
+        return [key for key in self.img2ami]
+
+    def getTag(self, tagList, tagKey):
+        if tagList:
+            for tag in tagList:
+                if tag["Key"] == tagKey: return tag["Value"]
+        return None
+
+    def getPartialOutput(self, vm):
+        domain_name = self.domainName(vm)
+        runcmd = "head -c %s autolab/feedback" % (config.Config.MAX_OUTPUT_FILE_SIZE)
+        sshcmd = (["ssh"] + self.ssh_flags + ["%s@%s" % (self.ec2User, domain_name), runcmd])
+        return subprocess.check_output(sshcmd, stderr=subprocess.STDOUT).decode("utf-8")

--- a/vmms/ec2Docker.py
+++ b/vmms/ec2Docker.py
@@ -134,6 +134,28 @@ class Ec2Docker(VMMSInterface):
         """Releases the VM sempahore"""
         Ec2Docker._vm_semaphore.release()
 
+    def refresh_ecr_images(self):
+        self.ecrImages = {}
+        try:
+            ecrClient = boto3.client("ecr", config.Config.EC2_REGION)
+
+            for repo_page in ecrClient.get_paginator("describe_repositories").paginate():
+                for repo in repo_page["repositories"]:
+                    repo_name = repo["repositoryName"]
+                    repo_uri = repo["repositoryUri"]
+
+                    for image_page in ecrClient.get_paginator("list_images").paginate(
+                        repositoryName=repo_name,
+                        filter={"tagStatus": "TAGGED"}
+                    ):
+                        for image_id in image_page.get("imageIds", []):
+                            tag = image_id.get("imageTag")
+                            if tag:
+                                self.ecrImages[f"{repo_uri}:{tag}"] = tag
+        except Exception as e:
+            self.log.error("Ec2Docker failed retrieving ECR images: %s" % (e))
+            raise
+
     def __init__(self, accessKeyId=None, accessKey=None):
         """log - logger for the instance
         connection - EC2Connection object that stores the connection
@@ -190,28 +212,8 @@ class Ec2Docker(VMMSInterface):
                 "Ignored images %s for lack of or ill-formed name tag"
                 % str(ignoredAMIs)
             )
-
-        self.ecrImages = {}
-        try:
-            ecrClient = boto3.client("ecr", config.Config.EC2_REGION)
-
-            for repo_page in ecrClient.get_paginator("describe_repositories").paginate():
-                for repo in repo_page["repositories"]:
-                    repo_name = repo["repositoryName"]
-                    repo_uri = repo["repositoryUri"]
-
-                    for image_page in ecrClient.get_paginator("list_images").paginate(
-                        repositoryName=repo_name,
-                        filter={"tagStatus": "TAGGED"}
-                    ):
-                        for image_id in image_page.get("imageIds", []):
-                            tag = image_id.get("imageTag")
-                            if tag:
-                                self.ecrImages[f"{repo_uri}:{tag}"] = tag
-        except Exception as e:
-            self.log.error("Ec2Docker failed retrieving ECR images: %s" % (e))
-            raise
-        print(self.ecrImages.keys())
+        
+        self.refresh_ecr_images()
 
     def instanceName(self, id, name):
         """instanceName - Constructs a VM instance name. Always use
@@ -519,6 +521,7 @@ class Ec2Docker(VMMSInterface):
         return False
 
     def getImages(self):
+        self.refresh_ecr_images()
         return [key for key in self.ecrImages]
 
     def getTag(self, tagList, tagKey):

--- a/vmms/ec2Docker.py
+++ b/vmms/ec2Docker.py
@@ -433,8 +433,8 @@ class Ec2Docker(VMMSInterface):
             f"docker run --rm {network_flag}-v /home/%s/autolab:/home/mount -w /home {vm.image} "
             "sh -c \"mkdir -p output && chown autolab:autolab output && "
             "cp -a mount/. autolab/ && chown -R autolab:autolab autolab/ && "
-            "su autolab -c \\\"/usr/bin/time --output=output/time.out autodriver "
-            "-u %d -f %d -t %d -o %d autolab > output/feedback 2>&1\\\" ; "
+            "su autolab -c \\\"autodriver "
+            "-u %d -f %d -t %d -o %d autolab > output/feedback 2>&1\\\" ; touch output/time.out ;"
             "cp output/feedback mount/ ; cp output/time.out mount/\""
             % (
                 self.ec2User,
@@ -444,6 +444,9 @@ class Ec2Docker(VMMSInterface):
                 maxOutputFileSize,
             )
         )
+
+        print("running command:")
+        print(runcmd)
 
         ret = timeout(["ssh"] + self.ssh_flags + ["%s@%s" % (self.ec2User, domain_name), runcmd], runTimeout * 2)
         return ret

--- a/vmms/ec2Docker.py
+++ b/vmms/ec2Docker.py
@@ -1,0 +1,841 @@
+#
+# Ec2Docker.py - Implements the Tango VMMS interface to run Tango jobs on Amazon EC2 using Docker.
+#
+# This implementation uses the AWS EC2 SDK to manage the virtual machines and
+# ssh and scp to access them. The following excecption are raised back
+# to the caller:
+#
+#   Ec2Exception - EC2 raises this if it encounters any problem
+#   ec2CallError - raised by ec2Call() function
+#
+
+import logging
+import os
+import re
+import subprocess
+import threading
+import time
+
+import backoff
+import boto3
+from botocore.exceptions import ClientError
+
+import config
+from tangoObjects import TangoMachine
+
+# suppress most boto logging
+logging.getLogger("boto3").setLevel(logging.CRITICAL)
+logging.getLogger("botocore").setLevel(logging.CRITICAL)
+logging.getLogger("urllib3.connectionpool").setLevel(logging.CRITICAL)
+
+
+def timeout(command, time_out=1):
+    """timeout - Run a unix command with a timeout. Return -1 on
+    timeout, otherwise return the return value from the command, which
+    is typically 0 for success, 1-255 for failure.
+    """
+
+    # Launch the command
+    p = subprocess.Popen(
+        command, stdout=open("/dev/null", "w"), stderr=subprocess.STDOUT
+    )
+
+    # Wait for the command to complete
+    t = 0.0
+    while t < time_out and p.poll() is None:
+        time.sleep(config.Config.TIMER_POLL_INTERVAL)
+        t += config.Config.TIMER_POLL_INTERVAL
+    if t >= time_out:
+        print("ERROR: timeout trying ", command)
+    # Determine why the while loop terminated
+    if p.poll() is None:
+        try:
+            os.kill(p.pid, 9)
+        except OSError:
+            pass
+        returncode = -1
+    else:
+        returncode = p.poll()
+    return returncode
+
+
+def timeout_with_retries(command, time_out=1, retries=3, retry_delay=2):
+    """timeout - Run a unix command with a timeout. Return -1 on
+    timeout, otherwise return the return value from the command, which
+    is typically 0 for success, 1-255 for failure.
+    """
+    for attempt in range(retries + 1):
+        # Launch the command
+        p = subprocess.Popen(
+            command, stdout=open("/dev/null", "w"), stderr=subprocess.STDOUT
+        )
+
+        # Wait for the command to complete
+        t = 0.0
+        while t < time_out and p.poll() is None:
+            time.sleep(config.Config.TIMER_POLL_INTERVAL)
+            t += config.Config.TIMER_POLL_INTERVAL
+        if t >= time_out:
+            print("ERROR: timeout trying ", command)
+
+        # Determine why the while loop terminated
+        if p.poll() is None:
+            try:
+                os.kill(p.pid, 9)
+            except OSError:
+                pass
+            returncode = -1
+        else:
+            returncode = p.poll()
+
+        # try to retry the command on a timeout
+        if returncode == -1:
+            if attempt < retries:
+                print(f"Retrying in {retry_delay} seconds...")
+                time.sleep(retry_delay)
+            else:
+                # attempt == retries -> failure
+                print("All retries exhausted.")
+                return -1
+        else:
+            return returncode
+
+
+def timeoutWithReturnStatus(command, time_out, returnValue=0):
+    """timeoutWithReturnStatus - Run a Unix command with a timeout,
+    until the expected value is returned by the command; On timeout,
+    return last error code obtained from the command.
+    """
+    p = subprocess.Popen(
+        command, stdout=open("/dev/null", "w"), stderr=subprocess.STDOUT
+    )
+    t = 0.0
+    while t < time_out:
+        ret = p.poll()
+        if ret is None:
+            time.sleep(config.Config.TIMER_POLL_INTERVAL)
+            t += config.Config.TIMER_POLL_INTERVAL
+        elif ret == returnValue:
+            return ret
+        else:
+            p = subprocess.Popen(
+                command, stdout=open("/dev/null", "w"), stderr=subprocess.STDOUT
+            )
+            return ret
+
+
+@backoff.on_exception(backoff.expo, ClientError, max_tries=3, jitter=None)
+def try_load_instance(newInstance):
+    newInstance.load()
+
+
+#
+# User defined exceptions
+#
+# ec2Call() exception
+
+
+class ec2CallError(Exception):
+    pass
+
+
+class Ec2Docker(object):
+    _SSH_FLAGS = [
+        "-i",
+        config.Config.SECURITY_KEY_PATH,
+        "-o",
+        "StrictHostKeyChecking no",
+        "-o",
+        "GSSAPIAuthentication no",
+    ]
+
+    # limit max number of VMS runnning per config
+    _vm_semaphore = threading.Semaphore(config.Config.MAX_EC2_VMS)
+
+    @staticmethod
+    def acquire_vm_semaphore():
+        """Blocks until a VM is available to limit load"""
+        Ec2Docker._vm_semaphore.acquire()  # This blocks until a slot is available
+
+    @staticmethod
+    def release_vm_semaphore():
+        """Releases the VM sempahore"""
+        Ec2Docker._vm_semaphore.release()
+
+    def __init__(self, accessKeyId=None, accessKey=None):
+        """log - logger for the instance
+        connection - EC2Connection object that stores the connection
+        info to the EC2 network
+        instance - Instance object that stores information about the
+        VM created
+        """
+        # do not do anything until we acquire a vm semaphore
+        Ec2Docker.acquire_vm_semaphore()
+
+        self.appName = os.path.basename(__file__).strip(".py")
+        # Setup logger
+        self.log = logging.getLogger("Ec2Docker-" + str(os.getpid()))
+        self.log.info("init Ec2Docker in program %s" % (self.appName))
+
+        # initialize EC2 USER
+        # PDL gets a ec2user in the parameter, just use the default
+        # user for now
+        self.ssh_flags = Ec2Docker._SSH_FLAGS
+        self.ec2User = config.Config.EC2_USER_NAME
+        self.useDefaultKeyPair = True
+
+        # key pair settings, for now, use default security key
+
+        # create boto3resource
+
+        self.img2ami = {}
+        self.images = []
+        try:
+            self.boto3resource = boto3.resource("ec2", config.Config.EC2_REGION)
+            self.boto3client = boto3.client("ec2", config.Config.EC2_REGION)
+
+            # Get images from ec2
+            images = self.boto3resource.images.filter(Owners=["self"])
+        except Exception as e:
+            self.log.error("Ec2Docker failed initialization: %s" % (e))
+            raise
+
+        for image in images:
+            if image.tags:
+                self.img2ami[image.id] = image
+                # for tag in image.tags:
+                #     if tag["Key"] == "Name" and tag["Value"]:
+                #         if tag["Value"] in self.img2ami:
+                #             self.log.info(
+                #                 "Ignore %s for duplicate name tag %s"
+                #                 % (image.id, tag["Value"])
+                #             )
+                #         else:
+                #             self.img2ami[tag["Value"]] = image
+                #             self.log.info(
+                #                 "Found image: %s with name tag %s"
+                #                 % (image.id, tag["Value"])
+                #             )
+
+        imageAMIs = [item.id for item in images]
+        taggedAMIs = [self.img2ami[key].id for key in self.img2ami]
+        ignoredAMIs = list(set(imageAMIs) - set(taggedAMIs))
+
+        if len(ignoredAMIs) > 0:
+            self.log.info(
+                "Ignored images %s for lack of or ill-formed name tag"
+                % str(ignoredAMIs)
+            )
+
+    def instanceName(self, id, name):
+        """instanceName - Constructs a VM instance name. Always use
+        this function when you need a VM instance name. Never generate
+        instance names manually.
+        """
+        return "%s-%d-%s" % (config.Config.PREFIX, id, name)
+
+    def keyPairName(self, id, name):
+        """keyPairName - Constructs a unique key pair name."""
+        return "%s-%d-%s" % (config.Config.PREFIX, id, name)
+
+    def domainName(self, vm):
+        """Returns the domain name that is stored in the vm
+        instance.
+        """
+        return vm.domain_name
+
+    #
+    # VMMS helper methods
+    #
+
+    def tangoMachineToEC2Instance(self, vm: TangoMachine):
+        """tangoMachineToEC2Instance - returns an object with EC2 instance
+        type and AMI. Only general-purpose instances are used. Defalt AMI
+        is currently used.
+        """
+        ec2instance = dict()
+
+        # Note: Unlike other vmms backend, instance type is chosen from
+        # the optional instance type attached to image name as
+        # "image+instance_type", such as my_course_mage+t2.small.
+
+        # for now , can only do default inst type
+        # TODO: choose instance type
+        if vm.instance_type is not None:
+            ec2instance["instance_type"] = vm.instance_type
+        else:
+            ec2instance["instance_type"] = config.Config.DEFAULT_INST_TYPE
+
+        # for now, ami is config default
+        # ec2instance["ami"] = self.img2ami[vm.image].id
+        ec2instance["ami"] = vm.image
+
+        self.log.info("tangoMachineToEC2Instance: %s" % str(ec2instance))
+        return ec2instance
+
+    def createKeyPair(self):
+        # TODO: SUPPORT
+        raise
+        # try to delete the key to avoid collision
+        self.key_pair_path = "%s/%s.pem" % (
+            config.Config.DYNAMIC_SECURITY_KEY_PATH,
+            self.key_pair_name,
+        )
+        self.deleteKeyPair()
+        key = self.connection.create_key_pair(self.key_pair_name)
+        key.save(config.Config.DYNAMIC_SECURITY_KEY_PATH)
+        # change the SSH_FLAG accordingly
+        self.ssh_flags[1] = self.key_pair_path
+
+    def deleteKeyPair(self):
+        # TODO: SUPPORT
+        raise
+        self.boto3client.delete_key_pair(self.key_pair_name)
+        # try to delete may not exist key file
+        try:
+            os.remove(self.key_pair_path)
+        except OSError:
+            pass
+
+    def createSecurityGroup(self):
+        try:
+            # Check if the security group already exists
+            response = self.boto3client.describe_security_groups(
+                Filters=[
+                    {
+                        "Name": "group-name",
+                        "Values": [config.Config.DEFAULT_SECURITY_GROUP],
+                    }
+                ]
+            )
+            if response["SecurityGroups"]:
+                security_group_id = response["SecurityGroups"][0]["GroupId"]
+                return
+        except Exception as e:
+            self.log.debug("ERROR checking for existing security group: %s", e)
+
+        try:
+            response = self.boto3resource.create_security_group(
+                GroupName=config.Config.DEFAULT_SECURITY_GROUP,
+                Description="Autolab security group - allowing all traffic",
+            )
+            security_group_id = response["GroupId"]
+            self.boto3resource.authorize_security_group_ingress(
+                GroupId=security_group_id
+            )
+        except Exception as e:
+            self.log.debug("ERROR in creating security group: %s", e)
+
+    #
+    # VMMS API functions
+    #
+    def initializeVM(self, vm):
+        """initializeVM - Tell EC2 to create a new VM instance.
+
+        Returns a boto.ec2.instance.Instance object.
+        """
+        newInstance = None
+        # Create the instance and obtain the reservation
+        try:
+            instanceName = self.instanceName(vm.id, vm.name)
+            ec2instance = self.tangoMachineToEC2Instance(vm)
+            self.log.debug("instanceName: %s" % instanceName)
+            # ensure that security group exists
+            self.createSecurityGroup()
+            if self.useDefaultKeyPair:
+                self.key_pair_name = config.Config.SECURITY_KEY_NAME
+                self.key_pair_path = config.Config.SECURITY_KEY_PATH
+            else:
+                # TODO: SUPPORT
+                raise
+                self.key_pair_name = self.keyPairName(vm.id, vm.name)
+                self.createKeyPair()
+
+            self.log.debug("starting ami image %s" % ec2instance["ami"])
+
+            reservation = self.boto3resource.create_instances(
+                ImageId=ec2instance["ami"],
+                KeyName=self.key_pair_name,
+                SecurityGroups=[config.Config.DEFAULT_SECURITY_GROUP],
+                InstanceType=ec2instance["instance_type"],
+                MaxCount=1,
+                MinCount=1,
+            )
+
+            # Sleep for a while to prevent random transient errors observed
+            # when the instance is not available yet
+            time.sleep(config.Config.TIMER_POLL_INTERVAL)
+
+            # reservation is a list of instances created. there is only
+            # one instance created so get index 0.
+            newInstance = reservation[0]
+            if not newInstance:
+                raise ValueError("Cannot find new instance for %s" % vm.name)
+
+            # Wait for instance to reach 'running' state
+            start_time = time.time()
+            while True:
+
+                filters = [
+                    {"Name": "instance-state-name", "Values": ["running"]}
+                ]
+                instances = self.boto3resource.instances.filter(Filters=filters)
+                instanceRunning = False
+
+                # reload the state of the new instance
+                try_load_instance(newInstance)
+                for inst in instances.filter(InstanceIds=[newInstance.id]):
+                    self.log.debug(
+                        "VM %s %s: is running" % (vm.name, newInstance.id)
+                    )
+                    instanceRunning = True
+
+                if instanceRunning:
+                    break
+
+                if (
+                    time.time() - start_time
+                    > config.Config.INITIALIZEVM_TIMEOUT
+                ):
+                    raise ValueError(
+                        "VM %s %s: timeout (%d seconds) before reaching 'running' state"
+                        % (
+                            vm.name,
+                            newInstance.id,
+                            config.Config.TIMER_POLL_INTERVAL,
+                        )
+                    )
+
+                self.log.debug(
+                    "VM %s %s: Waiting to reach 'running' from 'pending'"
+                    % (vm.name, newInstance.id)
+                )
+                time.sleep(config.Config.TIMER_POLL_INTERVAL)
+
+            # Assign name to EC2 instance
+            self.boto3resource.create_tags(
+                Resources=[newInstance.id],
+                Tags=[{"Key": "Name", "Value": vm.name}],
+            )
+
+            self.log.info(
+                "VM %s | State %s | Reservation %s | Public DNS Name %s | Public IP Address %s"
+                % (
+                    instanceName,
+                    newInstance.state,
+                    reservation,
+                    newInstance.public_dns_name,
+                    newInstance.public_ip_address,
+                )
+            )
+
+            # Save domain and id ssigned by EC2 in vm object
+            vm.domain_name = newInstance.public_ip_address
+            vm.instance_id = newInstance.id
+            self.log.debug("VM %s: %s" % (instanceName, newInstance))
+            return vm
+
+        except Exception as e:
+            self.log.debug("initializeVM Failed: %s" % e)
+
+            # if the new instance exists, terminate it
+            if newInstance:
+                try:
+                    self.boto3resource.instances.filter(
+                        InstanceIds=[newInstance.id]
+                    ).terminate()
+                except Exception as e:
+                    self.log.error(
+                        "Exception handling failed for %s: %s" % (vm.name, e)
+                    )
+                    return None
+            return None
+
+    def waitVM(self, vm, max_secs):
+        """waitVM - Wait at most max_secs for a VM to become
+        ready. Return error if it takes too long.
+
+        VM is a boto.ec2.instance.Instance object.
+        """
+        self.log.info("WaitVM: %s %s" % (vm.name, vm.instance_id))
+
+        # test if the vm is still an instance
+        if not self.existsVM(vm):
+            self.log.info("VM %s: no longer an instance", vm.name)
+            return -1
+        # First, wait for ping to the vm instance to work
+        instance_down = 1
+        start_time = time.time()
+        domain_name = self.domainName(vm)
+        self.log.info("WaitVM: pinging %s %s" % (domain_name, vm.name))
+        while instance_down:
+            instance_down = subprocess.call(
+                "ping -c 1 %s" % (domain_name),
+                shell=True,
+                stdout=open("/dev/null", "w"),
+                stderr=subprocess.STDOUT,
+            )
+
+            # Wait a bit and then try again if we haven't exceeded
+            # timeout
+            if instance_down:
+                time.sleep(config.Config.TIMER_POLL_INTERVAL)
+                elapsed_secs = time.time() - start_time
+                if elapsed_secs > max_secs:
+                    self.log.debug("WAITVM_TIMEOUT: %s", vm.id)
+                    return -1
+
+        # The ping worked, so now wait for SSH to work before
+        # declaring that the VM is ready
+        self.log.debug("VM %s: ping completed" % (vm.name))
+        while True:
+
+            elapsed_secs = time.time() - start_time
+
+            # Give up if the elapsed time exceeds the allowable time
+            if elapsed_secs > max_secs:
+                self.log.info(
+                    "VM %s: SSH timeout after %d secs" % (vm.name, elapsed_secs)
+                )
+                return -1
+
+            # If the call to ssh returns timeout (-1) or ssh error
+            # (255), then success. Otherwise, keep trying until we run
+            # out of time.
+            ret = timeout(
+                ["ssh"]
+                + self.ssh_flags
+                + ["%s@%s" % (self.ec2User, domain_name), "(:)"],
+                max_secs - elapsed_secs,
+            )
+
+            self.log.debug("VM %s: ssh returned with %d" % (vm.name, ret))
+
+            if (ret != -1) and (ret != 255):
+                return 0
+
+            # Sleep a bit before trying again
+            time.sleep(config.Config.TIMER_POLL_INTERVAL)
+
+    def copyIn(self, vm, inputFiles, job_id=None):
+        """copyIn - Copy input files to VM"""
+        self.log.info(
+            "copyIn %s - writing files" % self.instanceName(vm.id, vm.name)
+        )
+
+        domain_name = self.domainName(vm)
+
+        # Creates directory and add permissions
+        result = subprocess.run(
+            ["ssh"]
+            + self.ssh_flags
+            + [
+                "%s@%s" % (self.ec2User, domain_name),
+                "(mkdir -p autolab && chmod 775 autolab)",
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,  # To capture output as strings instead of bytes
+        )
+
+        # Print the output and error
+        for line in result.stdout:
+            self.log.info("%s for job %s" % (line, job_id))
+        self.log.info("Return Code: %s, job: %s" % (result.returncode, job_id))
+        if result.stderr != 0:
+            self.log.info(
+                "Standard Error: %s, job: %s" % (result.stderr, job_id)
+            )
+
+        # Validate inputFiles structure
+        if not inputFiles or not all(
+            hasattr(file, "localFile") and hasattr(file, "destFile")
+            for file in inputFiles
+        ):
+            self.log.info(
+                "Error: Invalid inputFiles Structure, job: %s" % job_id
+            )
+
+        for file in inputFiles:
+            self.log.info("%s - %s" % (file.localFile, file.destFile))
+            ret = timeout_with_retries(
+                ["scp"]
+                + self.ssh_flags
+                + [
+                    file.localFile,
+                    "%s@%s:~/autolab/%s"
+                    % (self.ec2User, domain_name, file.destFile),
+                ],
+                config.Config.COPYIN_TIMEOUT,
+            )
+            if ret != 0:
+                self.log.info("Copy-in Error: SCP failure, job: %s" % job_id)
+                return ret
+
+        return 0
+
+    def runJob(self, vm, runTimeout, maxOutputFileSize, disableNetwork):
+        """runJob - Run the make command on a VM using SSH and
+        redirect output to file "output".
+        """
+
+        domain_name = self.domainName(vm)
+        self.log.debug(
+            "runJob: Running job on VM %s" % self.instanceName(vm.id, vm.name)
+        )
+        args = ["docker load -i /opt/autolab-images/image.tar &&"]
+        args = ["docker", "run", "--rm", "--name", "autograding_container", "-v"]
+        args = args + ["/home/%s/autolab:%s" % (self.ec2User, "/home/mount")]
+        args = args + ["autolab/prebuild:autograding_image"]
+        args = args + ["sh", "-c"]
+        # Setting ulimits for VM and running job
+        runcmd = (
+            "/usr/bin/time --output=time.out autodriver \
+                -u %d -f %d -t %d -o %d autolab > output/feedback 2>&1 "
+            % (
+                config.Config.VM_ULIMIT_USER_PROC,
+                config.Config.VM_ULIMIT_FILE_SIZE,
+                runTimeout,
+                maxOutputFileSize,
+            )
+        )
+
+        args = args + [
+            '\"cp -r mount/* autolab/; su autolab -c "%s"; \
+                        cp output/feedback mount/feedback\"'
+            % runcmd
+        ]
+
+        # no logging for now
+
+        ret = timeout(
+            ["ssh"]
+            + self.ssh_flags
+            + ["%s@%s" % (self.ec2User, domain_name)]
+            + ["\""] + args + ["\""],
+            runTimeout * 2,
+        )
+
+        # runTimeout * 2 is a temporary hack. The driver will handle the timout
+        return ret
+
+    def copyOut(self, vm, destFile):
+        """copyOut - Copy the file output on the VM to the file
+        outputFile on the Tango host.
+        """
+        self.log.info(
+            "copyOut %s - writing to %s",
+            self.instanceName(vm.id, vm.name),
+            destFile,
+        )
+        domain_name = self.domainName(vm)
+
+        # Optionally log finer grained runtime info. Adds about 1 sec
+        # to the job latency, so we typically skip this.
+        if config.Config.LOG_TIMING:
+            try:
+                # regular expression matcher for error message from cat
+                no_file = re.compile("No such file or directory")
+
+                time_info = (
+                    subprocess.check_output(
+                        ["ssh"]
+                        + self.ssh_flags
+                        + [
+                            "%s@%s" % (self.ec2User, domain_name),
+                            "cat time.out",
+                        ]
+                    )
+                    .decode("utf-8")
+                    .rstrip("\n")
+                )
+
+                # If the output is empty, then ignore it (timing info wasn't
+                # collected), otherwise let's log it!
+                if no_file.match(time_info):
+                    # runJob didn't produce an output file
+                    pass
+
+                else:
+                    # remove newline character printed in timing info
+                    # replaces first '\n' character with a space
+                    time_info = re.sub("\n", " ", time_info, count=1)
+                    self.log.info("Timing (%s): %s" % (domain_name, time_info))
+
+            except subprocess.CalledProcessError as xxx_todo_changeme:
+                # Error copying out the timing data (probably runJob failed)
+                re.error = xxx_todo_changeme
+                # Error copying out the timing data (probably runJob failed)
+                pass
+
+        return timeout(
+            ["scp"]
+            + self.ssh_flags
+            + [
+                "%s@%s:~/autolab/feedback" % (config.Config.EC2_USER_NAME, domain_name),
+                destFile,
+            ],
+            config.Config.COPYOUT_TIMEOUT,
+        )
+
+    def destroyVM(self, vm):
+        """destroyVM - Removes a VM from the system"""
+        self.log.info(
+            "destroyVM: %s %s %s %s"
+            % (vm.instance_id, vm.name, vm.keep_for_debugging, vm.notes)
+        )
+
+        try:
+            instances = self.boto3resource.instances.filter(
+                InstanceIds=[vm.instance_id]
+            )
+            if not instances:
+                self.log.debug(
+                    "no instances found with instance id %s", vm.instance_id
+                )
+            # Keep the vm and mark with meaningful tags for debugging
+            if (
+                hasattr(config.Config, "KEEP_VM_AFTER_FAILURE")
+                and config.Config.KEEP_VM_AFTER_FAILURE
+                and vm.keep_for_debugging
+            ):
+                self.log.info("Will keep VM %s for further debugging" % vm.name)
+                # delete original name tag and replace it with "failed-xyz"
+                # add notes tag for test name
+                tag = self.boto3resource.Tag(vm.instance_id, "Name", vm.name)
+                if tag:
+                    tag.delete()
+                self.boto3resource.create_tags(
+                    Resources=[vm.instance_id],
+                    Tags=[
+                        {"Key": "Name", "Value": "failed-" + vm.name},
+                        {"Key": "Notes", "Value": vm.notes},
+                    ],
+                )
+                return
+
+            instances.terminate()
+            # delete dynamically created key
+            if not self.useDefaultKeyPair:
+                self.deleteKeyPair()
+        except Exception as e:
+            self.log.error(
+                "destroyVM failed: %s for vm %s" % (e, vm.instance_id)
+            )
+
+        Ec2Docker.release_vm_semaphore()
+
+    def safeDestroyVM(self, vm):
+        return self.destroyVM(vm)
+
+    def getVMs(self):
+        """getVMs - Returns the complete list of VMs on this account. Each
+        list entry is a boto.ec2.instance.Instance object.
+        """
+        try:
+            vms = list()
+            filters = [
+                {
+                    "Name": "instance-state-name",
+                    "Values": ["running", "pending"],
+                }
+            ]
+            # gets all running instances
+            instances = self.boto3resource.instances.filter(Filters=filters)
+            for instance in instances:
+                self.log.debug("instance_id: %s" % instance)
+
+                vm = TangoMachine()
+                vm.instance_id = instance.id
+                # don't use domain_name for now
+                vm.domain_name = None
+                vm.id = None
+
+                instName = self.getTag(
+                    instance.tags, "Name"
+                )  # inst name PREFIX-serial-IMAGE
+                # Name tag is the standard form of prefix-serial-image
+                if not (
+                    instName
+                    and re.match("%s-" % config.Config.PREFIX, instName)
+                ):
+                    self.log.debug(
+                        "getVMs: Instance id %s skipped" % vm.instance_id
+                    )
+                    continue  # instance without name tag or proper prefix
+
+                vm.name = instName
+                vm.id = int(instName.split("-")[1])
+                vm.pool = instName.split("-")[2]
+                vm.name = instName
+
+                # needed for SSH
+                if instance.public_ip_address:
+                    vm.domain_name = instance.public_ip_address
+
+                vms.append(vm)
+                self.log.debug(
+                    "getVMs: Instance id %s, name %s"
+                    % (vm.instance_id, vm.name)
+                )
+        except Exception as e:
+            self.log.debug("getVMs Failed: %s" % e)
+
+        return vms
+
+    def existsVM(self, vm):
+        """existsVM - Checks whether a VM exists in the vmms."""
+        # https://boto3.amazonaws.com/v1/documentation/api/latest/guide/migrationec2.html
+        filters = [{"Name": "instance-state-name", "Values": ["running"]}]
+        # gets all running instances
+        instances = self.boto3resource.instances.filter(Filters=filters)
+        for instance in instances:
+            if instance.instance_id == vm.instance_id:
+                self.log.debug(
+                    "Found matching instance_id: %s" % (instance.instance_id)
+                )
+                return True
+        # for instance in instances.filter(InstanceIds)
+        return False
+
+    def getImages(self):
+        """getImages - return a constant; actually use the ami specified in config"""
+        # return [key for key in self.img2ami]
+        try:
+            # Get images from ec2
+            images = self.boto3resource.images.filter(Owners=["self"])
+        except Exception as e:
+            self.log.error("Ec2Docker failed getting images: %s" % (e))
+            raise
+
+        for image in images:
+            if image.tags:
+                self.img2ami[image.id] = image
+        return [value.id for value in self.img2ami.values()]
+
+    # getTag: to do later
+    def getTag(self, tagList, tagKey):
+        if tagList:
+            for tag in tagList:
+                if tag["Key"] == tagKey:
+                    return tag["Value"]
+        return None
+
+    def getPartialOutput(self, vm):
+        domain_name = self.domainName(vm)
+
+        runcmd = "head -c %s /home/autograde/output.log" % (
+            config.Config.MAX_OUTPUT_FILE_SIZE
+        )
+
+        sshcmd = (
+            ["ssh"]
+            + self.ssh_flags
+            + ["%s@%s" % (self.ec2User, domain_name), runcmd]
+        )
+
+        output = subprocess.check_output(
+            sshcmd, stderr=subprocess.STDOUT
+        ).decode("utf-8")
+
+        return output

--- a/vmms/ec2Docker.py
+++ b/vmms/ec2Docker.py
@@ -488,7 +488,7 @@ class Ec2Docker(VMMSInterface):
             f"aws ecr get-login-password --region {region} | "
             f"docker login --username AWS --password-stdin {registry_url} && "
             f"docker run --rm {network_flag}-v /home/%s/autolab:/home/mount -w /home {vm.image} "
-            "sh -c \"mkdir -p output && chown autolab:autolab output && "
+            "sh -c \"cd /home && mkdir -p output && chown autolab:autolab output && "
             "cp -a mount/. autolab/ && chown -R autolab:autolab autolab/ && "
             "su autolab -c \\\"autodriver "
             "-u %d -f %d -t %d -o %d autolab > output/feedback 2>&1\\\" ; touch output/time.out ;"

--- a/vmms/ec2Docker.py
+++ b/vmms/ec2Docker.py
@@ -163,7 +163,6 @@ class Ec2Docker(VMMSInterface):
             raise
 
         self.img2ami = {} 
-        self.images = []
         try:
             self.boto3resource: EC2ServiceResource = boto3.resource("ec2", config.Config.EC2_REGION)
             self.boto3client = boto3.client("ec2", config.Config.EC2_REGION)
@@ -191,6 +190,28 @@ class Ec2Docker(VMMSInterface):
                 "Ignored images %s for lack of or ill-formed name tag"
                 % str(ignoredAMIs)
             )
+
+        self.ecrImages = {}
+        try:
+            ecrClient = boto3.client("ecr", config.Config.EC2_REGION)
+
+            for repo_page in ecrClient.get_paginator("describe_repositories").paginate():
+                for repo in repo_page["repositories"]:
+                    repo_name = repo["repositoryName"]
+                    repo_uri = repo["repositoryUri"]
+
+                    for image_page in ecrClient.get_paginator("list_images").paginate(
+                        repositoryName=repo_name,
+                        filter={"tagStatus": "TAGGED"}
+                    ):
+                        for image_id in image_page.get("imageIds", []):
+                            tag = image_id.get("imageTag")
+                            if tag:
+                                self.ecrImages[f"{repo_uri}:{tag}"] = tag
+        except Exception as e:
+            self.log.error("Ec2Docker failed retrieving ECR images: %s" % (e))
+            raise
+        print(self.ecrImages.keys())
 
     def instanceName(self, id, name):
         """instanceName - Constructs a VM instance name. Always use
@@ -472,7 +493,7 @@ class Ec2Docker(VMMSInterface):
         return False
 
     def getImages(self):
-        return [key for key in self.img2ami]
+        return [key for key in self.ecrImages]
 
     def getTag(self, tagList, tagKey):
         if tagList:

--- a/vmms/ec2Docker.py
+++ b/vmms/ec2Docker.py
@@ -349,12 +349,16 @@ class Ec2Docker(VMMSInterface):
     def waitVM(self, vm, max_secs) -> Literal[0, -1]:
         """Polls the instance until network and SSH drivers are responsive."""
         self.log.info("WaitVM: %s %s" % (vm.name, vm.instance_id))
-        if not self.existsVM(vm): return -1
-            
+        if not self.existsVM(vm):
+            self.log.info("VM %s: no longer an instance", vm.name)
+            return -1
+        
+        # First, wait for ping to the vm instance to work
         instance_down = 1
         start_time = time.time()
         domain_name = self.domainName(vm)
         
+        self.log.info("WaitVM: pinging %s %s" % (domain_name, vm.name))
         while instance_down:
             instance_down = subprocess.call(
                 "ping -c 1 %s" % (domain_name), shell=True,
@@ -362,16 +366,35 @@ class Ec2Docker(VMMSInterface):
             )
             if instance_down:
                 time.sleep(config.Config.TIMER_POLL_INTERVAL)
-                if (time.time() - start_time) > max_secs: return -1
+                if (time.time() - start_time) > max_secs:
+                    self.log.debug("WAITVM_TIMEOUT: %s", vm.id)
+                    return -1
 
+        # The ping worked, so now wait for SSH to work before
+        # declaring that the VM is ready
+        self.log.debug("VM %s: ping completed" % (vm.name))
         while True:
             elapsed_secs = time.time() - start_time
-            if elapsed_secs > max_secs: return -1
+
+            # Give up if the elapsed time exceeds the allowable time
+            if elapsed_secs > max_secs:
+                self.log.info(
+                    "VM %s: SSH timeout after %d secs" % (vm.name, elapsed_secs)
+                )
+                return -1
+            
+            # If the call to ssh returns timeout (-1) or ssh error
+            # (255), then success. Otherwise, keep trying until we run
+            # out of time.
             ret = timeout(
                 ["ssh"] + self.ssh_flags + ["%s@%s" % (self.ec2User, domain_name), "(:)"],
                 max_secs - elapsed_secs,
             )
-            if (ret != -1) and (ret != 255): return 0
+
+            self.log.debug("VM %s: ssh returned with %d" % (vm.name, ret))
+
+            if (ret != -1) and (ret != 255):
+                return 0
             time.sleep(config.Config.TIMER_POLL_INTERVAL)
 
     def copyIn(self, vm, inputFiles, job_id=None):

--- a/vmms/ec2SSH.py
+++ b/vmms/ec2SSH.py
@@ -153,6 +153,10 @@ class Ec2SSH(VMMSInterface):
         "-o",
         "StrictHostKeyChecking no",
         "-o",
+        "UserKnownHostsFile=/dev/null",
+        "-o",
+        "GlobalKnownHostsFile=/dev/null",
+        "-o",
         "GSSAPIAuthentication no",
     ]
 
@@ -169,6 +173,36 @@ class Ec2SSH(VMMSInterface):
         """Releases the VM sempahore"""
         Ec2SSH._vm_semaphore.release()
 
+    @staticmethod
+    def _validate_ec2_runtime_config() -> str:
+        """Validate required EC2 configuration and return normalized key path."""
+        missing = []
+
+        if not str(config.Config.EC2_REGION).strip():
+            missing.append("EC2_REGION")
+        if not str(config.Config.EC2_USER_NAME).strip():
+            missing.append("EC2_USER_NAME")
+        if not str(config.Config.SECURITY_KEY_PATH).strip():
+            missing.append("SECURITY_KEY_PATH")
+
+        if missing:
+            raise ValueError(
+                "Missing required EC2 configuration: %s"
+                % ", ".join(missing)
+            )
+
+        key_path = os.path.expanduser(str(config.Config.SECURITY_KEY_PATH).strip())
+        if not os.path.isfile(key_path):
+            raise ValueError(
+                "Invalid SECURITY_KEY_PATH (file does not exist): %s" % key_path
+            )
+        if not os.access(key_path, os.R_OK):
+            raise ValueError(
+                "Invalid SECURITY_KEY_PATH (file is not readable): %s" % key_path
+            )
+
+        return key_path
+
     # TODO: the arguments accessKeyId and accessKey don't do anything
     def __init__(self, accessKeyId=None, accessKey=None):
         """log - logger for the instance
@@ -177,6 +211,8 @@ class Ec2SSH(VMMSInterface):
         instance - Instance object that stores information about the
         VM created
         """
+        validated_key_path = Ec2SSH._validate_ec2_runtime_config()
+
         # do not do anything until we acquire a vm semaphore
         Ec2SSH.acquire_vm_semaphore()
 
@@ -188,14 +224,16 @@ class Ec2SSH(VMMSInterface):
         # initialize EC2 USER
         # PDL gets a ec2user in the parameter, just use the default
         # user for now
-        self.ssh_flags = Ec2SSH._SSH_FLAGS
-        self.ec2User = config.Config.EC2_USER_NAME
+        self.ssh_flags = Ec2SSH._SSH_FLAGS.copy()
+        self.ssh_flags[1] = validated_key_path
+        self.ec2User = str(config.Config.EC2_USER_NAME).strip()
+        self.ec2Region = str(config.Config.EC2_REGION).strip()
         self.useDefaultKeyPair = True
 
         # key pair settings, for now, use default security key
         if self.useDefaultKeyPair:
             self.key_pair_name: str = config.Config.SECURITY_KEY_NAME
-            self.key_pair_path: str = config.Config.SECURITY_KEY_PATH
+            self.key_pair_path: str = validated_key_path
         else:
             # TODO: SUPPORT. Know that this if/else block used to be under initializeVM, using vm for a unique identifier
             raise
@@ -207,8 +245,8 @@ class Ec2SSH(VMMSInterface):
         self.images = []
         try:
             # This is a service resource
-            self.boto3resource: EC2ServiceResource = boto3.resource("ec2", config.Config.EC2_REGION) # TODO: rename this ot self.ec2resource
-            self.boto3client = boto3.client("ec2", config.Config.EC2_REGION)
+            self.boto3resource: EC2ServiceResource = boto3.resource("ec2", self.ec2Region) # TODO: rename this ot self.ec2resource
+            self.boto3client = boto3.client("ec2", self.ec2Region)
 
             # Get images from ec2
             images = self.boto3resource.images.filter(Owners=["self"])

--- a/vmms/ec2SSH.py
+++ b/vmms/ec2SSH.py
@@ -212,10 +212,18 @@ class Ec2SSH(VMMSInterface):
 
         key_mode = stat.S_IMODE(os.stat(key_path).st_mode)
         if key_mode & 0o077:
-            raise ValueError(
-                "Invalid SECURITY_KEY_PATH permissions for private key %s (mode %o). "
-                "Expected chmod 600 (or stricter)." % (key_path, key_mode)
-            )
+            # Try to auto-fix common container mount permission issue.
+            try:
+                os.chmod(key_path, 0o600)
+            except OSError:
+                pass
+
+            key_mode = stat.S_IMODE(os.stat(key_path).st_mode)
+            if key_mode & 0o077:
+                raise ValueError(
+                    "Invalid SECURITY_KEY_PATH permissions for private key %s (mode %o). "
+                    "Expected chmod 600 (or stricter)." % (key_path, key_mode)
+                )
 
         return key_path
 

--- a/vmms/ec2SSH.py
+++ b/vmms/ec2SSH.py
@@ -12,6 +12,7 @@
 import logging
 import os
 import re
+import stat
 import subprocess
 import threading
 import time
@@ -157,6 +158,14 @@ class Ec2SSH(VMMSInterface):
         "-o",
         "GlobalKnownHostsFile=/dev/null",
         "-o",
+        "BatchMode yes",
+        "-o",
+        "IdentitiesOnly yes",
+        "-o",
+        "PreferredAuthentications publickey",
+        "-o",
+        "ConnectTimeout 5",
+        "-o",
         "GSSAPIAuthentication no",
     ]
 
@@ -199,6 +208,13 @@ class Ec2SSH(VMMSInterface):
         if not os.access(key_path, os.R_OK):
             raise ValueError(
                 "Invalid SECURITY_KEY_PATH (file is not readable): %s" % key_path
+            )
+
+        key_mode = stat.S_IMODE(os.stat(key_path).st_mode)
+        if key_mode & 0o077:
+            raise ValueError(
+                "Invalid SECURITY_KEY_PATH permissions for private key %s (mode %o). "
+                "Expected chmod 600 (or stricter)." % (key_path, key_mode)
             )
 
         return key_path

--- a/vmms/ecrBuilder.py
+++ b/vmms/ecrBuilder.py
@@ -173,6 +173,27 @@ Pin-Priority: -1
             status_id=255,
             status_msg=f"Build failed: {str(e)}",
         )
+    finally:
+        print("Cleaning up local Docker storage...")
+        try:
+            # Remove the final built image from the EC2 drive
+            if 'full_image_name' in locals():
+                docker_client.images.remove(image=full_image_name, force=True)
+            
+            # Remove the base template image (if it was pulled)
+            if base_uri is not None:
+                docker_client.images.remove(image=base_uri, force=True)
+            if base_tag is not None:
+                docker_client.images.remove(image=base_tag, force=True)
+            
+            #  Prune intermediate `<none>:<none>` dangling layers
+            prune_result = docker_client.images.prune(filters={'dangling': True})
+            reclaimed = prune_result.get('SpaceReclaimed', 0) / (1024 * 1024) # Convert bytes to MB
+            print(f"Cleanup successful. Reclaimed {reclaimed:.2f} MB of dangling cache.")
+            
+        except Exception as cleanup_error:
+            # We catch exceptions here so a cleanup failure doesn't crash the Tango daemon
+            print(f"Cleanup warning: {cleanup_error}")
 
 def get_build_status(job_id):
     with build_jobs_lock:

--- a/vmms/ecrBuilder.py
+++ b/vmms/ecrBuilder.py
@@ -102,7 +102,12 @@ Pin-Priority: -1
             full_image_name = f"{registry}/{course_id}:{version_tag}"
 
             # Build the image locally
-            docker_client.images.build(path=tmpdir, tag=full_image_name)
+            _, logs = docker_client.images.build(path=tmpdir, tag=full_image_name)
+            for chunk in logs:
+                if "stream" in chunk:
+                    print(chunk["stream"], end="")
+                if "error" in chunk:
+                    print("BUILD ERROR:", chunk["error"])
 
             print("Pushing docker image %s to ECR" % image_name)
             # Push to ECR
@@ -115,15 +120,15 @@ Pin-Priority: -1
                 .tag(f"{registry}/{course_id}:{stable_tag}")
 
         # On Success
-        build_jobs[job_id]["statusId"] = 0
+        build_jobs[job_id]["statusId"] = 2
         build_jobs[job_id]["statusMsg"] = "Image built successfully"
         build_jobs[job_id]["ecrImageUri"] = full_image_name
 
     except Exception as e:
         print(("Build failed: %s" % e))
         # On Failure
-        build_jobs[job_id]["statusId"] = -1
+        build_jobs[job_id]["statusId"] = 255
         build_jobs[job_id]["statusMsg"] = f"Build failed: {str(e)}"
 
 def get_build_status(job_id):
-    return build_jobs.get(str(job_id), {"statusId": -1, "statusMsg": "Job not found"})
+    return build_jobs.get(str(job_id), {"statusId": 255, "statusMsg": "Job not found"})

--- a/vmms/ecrBuilder.py
+++ b/vmms/ecrBuilder.py
@@ -5,6 +5,7 @@ import os
 import docker
 import boto3
 import base64
+import json
 
 # In-memory dictionary to track build status
 build_jobs = {}
@@ -38,6 +39,30 @@ def _build_and_push_task(job_id, course_id, image_name, tag, dockerfile_content)
             ecr_client.describe_repositories(repositoryNames=[image_name])
         except ecr_client.exceptions.RepositoryNotFoundException:
             ecr_client.create_repository(repositoryName=image_name)
+            
+            # Apply Lifecycle Policy to automatically expire old images
+            policy_text = json.dumps({
+                "rules": [
+                    {
+                        "rulePriority": 1,
+                        "description": "Expire images older than 180 days",
+                        "selection": {
+                            "tagStatus": "any",
+                            "countType": "sinceImagePushed",
+                            "countUnit": "days",
+                            "countNumber": 180
+                        },
+                        "action": {
+                            "type": "expire"
+                        }
+                    }
+                ]
+            })
+            
+            ecr_client.put_lifecycle_policy(
+                repositoryName=image_name,
+                lifecyclePolicyText=policy_text
+            )
 
         auth_response = ecr_client.get_authorization_token()
         auth_data = auth_response['authorizationData'][0]

--- a/vmms/ecrBuilder.py
+++ b/vmms/ecrBuilder.py
@@ -36,7 +36,7 @@ def append_build_log(job_id, message):
     with build_jobs_lock:
         build_jobs[str(job_id)]["logs"].append(message)
 
-def start_ecr_build(course_id, job_id, image_name, dockerfile_content):
+def start_ecr_build(course_id, job_id, image_name, dockerfile_content, base_tag, base_uri):
     print("Starting build with job_id=%s" % job_id)
     
     create_build_job(
@@ -48,15 +48,18 @@ def start_ecr_build(course_id, job_id, image_name, dockerfile_content):
     # Spin up background thread to avoid blocking the API
     thread = threading.Thread(
         target=_build_and_push_task,
-        args=(job_id, course_id, image_name, dockerfile_content)
+        args=(job_id, course_id, image_name, dockerfile_content, base_tag, base_uri)
     )
     thread.daemon = True
     thread.start()
 
     return int(job_id)
 
-def _build_and_push_task(job_id, course_id, image_name, dockerfile_content):
-    version_tag = f"{image_name}-{int(time.time())}"
+def _build_and_push_task(job_id, course_id, image_name, dockerfile_content, base_tag, base_uri):
+    if course_id is "public":
+        ecr_tag = image_name
+    else:
+        ecr_tag = f"{image_name}-{int(time.time())}"
     stable_tag = image_name
     try:
         # Authenticate with AWS ECR
@@ -103,6 +106,11 @@ def _build_and_push_task(job_id, course_id, image_name, dockerfile_content):
         docker_client = docker.from_env()
         docker_client.login(username=username, password=password, registry=registry)
 
+        print("Pulling remote docker image %s" % base_tag)
+        if base_tag is not None and base_uri is not None:
+            docker_client.images.pull(base_uri)
+            docker_client.images.get(base_uri).tag(base_tag)
+
         # Write Dockerfile to temp directory
         with tempfile.TemporaryDirectory() as tmpdir:
             print("Copying dockerfile %s" % image_name)
@@ -119,7 +127,7 @@ Pin-Priority: -1
             with open(apt_preferences_path, 'w') as f:
                 f.write(apt_preferences_content)
 
-            full_image_name = f"{registry}/{course_id}:{version_tag}"
+            full_image_name = f"{registry}/{course_id}:{ecr_tag}"
             repository = f"{registry}/{course_id}"
 
             # Build the image locally
@@ -141,7 +149,7 @@ Pin-Priority: -1
 
             print("Pushing docker image %s to ECR" % image_name)
             # Push to ECR
-            push_logs = docker_client.images.push(repository=repository, tag=version_tag, stream=True, decode=True)
+            push_logs = docker_client.images.push(repository=repository, tag=ecr_tag, stream=True, decode=True)
             for log in push_logs:
                 if 'error' in log:
                     raise Exception(log['error'])

--- a/vmms/ecrBuilder.py
+++ b/vmms/ecrBuilder.py
@@ -11,15 +11,31 @@ from config import Config
 
 # In-memory dictionary to track build status
 build_jobs = {}
+build_jobs_lock = threading.RLock()
+
+def create_build_job(job_id, status_id, status_msg):
+    with build_jobs_lock:
+        build_jobs[str(job_id)] = {
+            "statusMsg": "Building image in ECR",
+            "statusId": 1,
+            "jobId": int(job_id)
+        }
+
+def update_build_job(job_id, status_id, status_msg, uri=None):
+    with build_jobs_lock:
+        build_jobs[str(job_id)]["statusId"] = status_id
+        build_jobs[str(job_id)]["statusMsg"] = status_msg
+        if uri != None:
+            build_jobs[str(job_id)]["ecrImageUri"] = uri
 
 def start_ecr_build(course_id, job_id, image_name, dockerfile_content):
     print("Starting build with job_id=%s" % job_id)
     
-    build_jobs[str(job_id)] = {
-        "statusMsg": "Building image in ECR",
-        "statusId": 1,
-        "jobId": int(job_id)
-    }
+    create_build_job(
+        job_id=int(job_id),
+        status_id=1,
+        status_msg="Building image in ECR"
+    )
 
     # Spin up background thread to avoid blocking the API
     thread = threading.Thread(
@@ -117,15 +133,21 @@ Pin-Priority: -1
 
         print("Build all done!")
         # On Success
-        build_jobs[str(job_id)]["statusId"] = 2
-        build_jobs[str(job_id)]["statusMsg"] = "Image built successfully"
-        build_jobs[str(job_id)]["ecrImageUri"] = full_image_name
+        update_build_job(
+            job_id=job_id,
+            status_id=2,
+            status_msg="Image built successfully",
+            uri=full_image_name
+        )
 
     except Exception as e:
         print(("Build failed: %s" % e))
         # On Failure
-        build_jobs[str(job_id)]["statusId"] = 255
-        build_jobs[str(job_id)]["statusMsg"] = f"Build failed: {str(e)}"
+        update_build_job(
+            job_id=job_id,
+            status_id=255,
+            status_msg=f"Build failed: {str(e)}",
+        )
 
 def get_build_status(job_id):
     return build_jobs.get(str(job_id), {"statusId": 255, "statusMsg": "Job not found"})

--- a/vmms/ecrBuilder.py
+++ b/vmms/ecrBuilder.py
@@ -82,7 +82,7 @@ def _build_and_push_task(job_id, course_id, image_name, dockerfile_content):
 
         # Write Dockerfile to temp directory
         with tempfile.TemporaryDirectory() as tmpdir:
-            print("Creating docker image %s" % image_name)
+            print("Copying dockerfile %s" % image_name)
             dockerfile_path = os.path.join(tmpdir, 'Dockerfile')
             with open(dockerfile_path, 'w') as f:
                 f.write(dockerfile_content)
@@ -97,9 +97,11 @@ Pin-Priority: -1
                 f.write(apt_preferences_content)
 
             full_image_name = f"{registry}/{course_id}:{version_tag}"
+            repository = f"{registry}/{course_id}"
 
             # Build the image locally
-            _, logs = docker_client.images.build(path=tmpdir, tag=full_image_name)
+            print("Building the docker image %s" % image_name)
+            logs = docker_client.api.build(path=tmpdir, tag=full_image_name)
             for chunk in logs:
                 if "stream" in chunk:
                     print(chunk["stream"], end="")
@@ -108,25 +110,22 @@ Pin-Priority: -1
 
             print("Pushing docker image %s to ECR" % image_name)
             # Push to ECR
-            push_logs = docker_client.images.push(full_image_name, stream=True, decode=True)
+            push_logs = docker_client.images.push(repository=repository, tag=version_tag, stream=True, decode=True)
             for log in push_logs:
                 if 'error' in log:
                     raise Exception(log['error'])
-            # Tag it with the stable image name
-            docker_client.images.get(full_image_name) \
-                .tag(f"{registry}/{course_id}:{stable_tag}")
 
+        print("Build all done!")
         # On Success
-        build_jobs[job_id]["statusId"] = 2
-        build_jobs[job_id]["statusMsg"] = "Image built successfully"
-        build_jobs[job_id]["ecrImageUri"] = full_image_name
+        build_jobs[str(job_id)]["statusId"] = 2
+        build_jobs[str(job_id)]["statusMsg"] = "Image built successfully"
+        build_jobs[str(job_id)]["ecrImageUri"] = full_image_name
 
     except Exception as e:
         print(("Build failed: %s" % e))
         # On Failure
-        build_jobs[job_id]["statusId"] = 255
-        build_jobs[job_id]["statusMsg"] = f"Build failed: {str(e)}"
+        build_jobs[str(job_id)]["statusId"] = 255
+        build_jobs[str(job_id)]["statusMsg"] = f"Build failed: {str(e)}"
 
 def get_build_status(job_id):
-    print(build_jobs)
     return build_jobs.get(str(job_id), {"statusId": 255, "statusMsg": "Job not found"})

--- a/vmms/ecrBuilder.py
+++ b/vmms/ecrBuilder.py
@@ -12,7 +12,9 @@ build_jobs = {}
 
 def start_ecr_build(course_id, image_name, tag, dockerfile_content):
     # Generate a numeric ID to match the JOBID regex in server.py
+    #TODO: fix job_id collision, add locks
     job_id = str(random.randint(10000, 999999))
+    print("Starting build with job_id=%s" % job_id)
     
     build_jobs[job_id] = {
         "statusMsg": "Building image in ECR",
@@ -35,9 +37,11 @@ def _build_and_push_task(job_id, course_id, image_name, tag, dockerfile_content)
         # Authenticate with AWS ECR
         ecr_client = boto3.client('ecr', region_name='us-east-2')
         
+        print("Connecting to ECR repository")
         try:
             ecr_client.describe_repositories(repositoryNames=[image_name])
         except ecr_client.exceptions.RepositoryNotFoundException:
+            print("Creating ECR repository")
             ecr_client.create_repository(repositoryName=image_name)
             
             # Apply Lifecycle Policy to automatically expire old images
@@ -74,8 +78,10 @@ def _build_and_push_task(job_id, course_id, image_name, tag, dockerfile_content)
         docker_client = docker.from_env()
         docker_client.login(username=username, password=password, registry=registry)
 
+
         # Write Dockerfile to temp directory
         with tempfile.TemporaryDirectory() as tmpdir:
+            print("Creating docker image %s" % image_name)
             dockerfile_path = os.path.join(tmpdir, 'Dockerfile')
             with open(dockerfile_path, 'w') as f:
                 f.write(dockerfile_content)
@@ -85,6 +91,7 @@ def _build_and_push_task(job_id, course_id, image_name, tag, dockerfile_content)
             # Build the image locally
             docker_client.images.build(path=tmpdir, tag=full_image_name)
 
+            print("Pushing docker image %s to ECR" % image_name)
             # Push to ECR
             push_logs = docker_client.images.push(full_image_name, stream=True, decode=True)
             for log in push_logs:
@@ -94,7 +101,7 @@ def _build_and_push_task(job_id, course_id, image_name, tag, dockerfile_content)
         # On Success
         build_jobs[job_id]["statusId"] = 0
         build_jobs[job_id]["statusMsg"] = "Image built successfully"
-        build_jobs[job_id]["ecr_image_uri"] = full_image_name
+        build_jobs[job_id]["ecrImageUri"] = full_image_name
 
     except Exception as e:
         # On Failure

--- a/vmms/ecrBuilder.py
+++ b/vmms/ecrBuilder.py
@@ -56,6 +56,8 @@ def start_ecr_build(course_id, job_id, image_name, dockerfile_content, base_tag,
     return int(job_id)
 
 def _build_and_push_task(job_id, course_id, image_name, dockerfile_content, base_tag, base_uri):
+    course_id = course_id.lower()
+    image_name = image_name.lower()
     if course_id is "public":
         ecr_tag = image_name
     else:
@@ -182,11 +184,8 @@ def get_build_status(job_id):
                 "logs": []
             }
 
-        # retrieve the most recent logs
+        # Retrieve the FULL log history
         logs = list(job.get("logs", []))
-
-        # clear logs (consume-on-read)
-        job["logs"] = []
 
         res = {
             "statusId": int(job["statusId"]),

--- a/vmms/ecrBuilder.py
+++ b/vmms/ecrBuilder.py
@@ -103,7 +103,6 @@ def _build_and_push_task(job_id, course_id, image_name, dockerfile_content):
         docker_client = docker.from_env()
         docker_client.login(username=username, password=password, registry=registry)
 
-
         # Write Dockerfile to temp directory
         with tempfile.TemporaryDirectory() as tmpdir:
             print("Copying dockerfile %s" % image_name)
@@ -132,7 +131,7 @@ Pin-Priority: -1
                     append_build_log(job_id, chunk["stream"])
                 if "error" in chunk:
                     print("BUILD ERROR:", chunk["error"])
-                    append_build_log(job_id, chunk["stream"])
+                    append_build_log(job_id, chunk["error"])
 
             print("Pushing docker image %s to ECR" % image_name)
             # Push to ECR

--- a/vmms/ecrBuilder.py
+++ b/vmms/ecrBuilder.py
@@ -12,13 +12,10 @@ from config import Config
 # In-memory dictionary to track build status
 build_jobs = {}
 
-def start_ecr_build(course_id, image_name, dockerfile_content):
-    # Generate a numeric ID to match the JOBID regex in server.py
-    #TODO: fix job_id collision, add locks
-    job_id = str(random.randint(10000, 999999))
+def start_ecr_build(course_id, job_id, image_name, dockerfile_content):
     print("Starting build with job_id=%s" % job_id)
     
-    build_jobs[job_id] = {
+    build_jobs[str(job_id)] = {
         "statusMsg": "Building image in ECR",
         "statusId": 1,
         "jobId": int(job_id)
@@ -131,4 +128,5 @@ Pin-Priority: -1
         build_jobs[job_id]["statusMsg"] = f"Build failed: {str(e)}"
 
 def get_build_status(job_id):
+    print(build_jobs)
     return build_jobs.get(str(job_id), {"statusId": 255, "statusMsg": "Job not found"})

--- a/vmms/ecrBuilder.py
+++ b/vmms/ecrBuilder.py
@@ -16,17 +16,25 @@ build_jobs_lock = threading.RLock()
 def create_build_job(job_id, status_id, status_msg):
     with build_jobs_lock:
         build_jobs[str(job_id)] = {
-            "statusMsg": "Building image in ECR",
-            "statusId": 1,
-            "jobId": int(job_id)
+            "statusMsg": status_msg,
+            "statusId": status_id,
+            "jobId": int(job_id),
+            "logs": [],
+            "logCursor": 0,
         }
 
-def update_build_job(job_id, status_id, status_msg, uri=None):
+def update_build_job(job_id, status_id, status_msg, uri=None, log_cursor=None):
     with build_jobs_lock:
         build_jobs[str(job_id)]["statusId"] = status_id
         build_jobs[str(job_id)]["statusMsg"] = status_msg
         if uri != None:
             build_jobs[str(job_id)]["ecrImageUri"] = uri
+        if log_cursor != None:
+            build_jobs[str(job_id)]["logCursor"] = log_cursor
+
+def append_build_log(job_id, message):
+    with build_jobs_lock:
+        build_jobs[str(job_id)]["logs"].append(message)
 
 def start_ecr_build(course_id, job_id, image_name, dockerfile_content):
     print("Starting build with job_id=%s" % job_id)
@@ -121,8 +129,10 @@ Pin-Priority: -1
             for chunk in logs:
                 if "stream" in chunk:
                     print(chunk["stream"], end="")
+                    append_build_log(job_id, chunk["stream"])
                 if "error" in chunk:
                     print("BUILD ERROR:", chunk["error"])
+                    append_build_log(job_id, chunk["stream"])
 
             print("Pushing docker image %s to ECR" % image_name)
             # Push to ECR
@@ -150,9 +160,40 @@ Pin-Priority: -1
         )
 
 def get_build_status(job_id):
-    return build_jobs.get(str(job_id), {"statusId": 255, "statusMsg": "Job not found"})
+    with build_jobs_lock:
+        job = build_jobs.get(str(job_id))
+        if job is None:
+            return {
+                "statusId": 255,
+                "statusMsg": "Job not found",
+                "logs": []
+            }
+
+        # retrieve the most recent logs
+        logs = list(job.get("logs", []))
+
+        # clear logs (consume-on-read)
+        job["logs"] = []
+
+        res = {
+            "statusId": int(job["statusId"]),
+            "statusMsg": job["statusMsg"],
+            "logs": logs,
+        }
+
+        if "ecrImageUri" in job:
+            res["ecrImageUri"] = job["ecrImageUri"]
+
+        # mark terminal jobs
+        if job["statusId"] in (2, 255):
+            job["done"] = True
+
+        return res
 
 def get_all_build_status():
+    all_jobs = {}
+    for job in build_jobs.values():
+        all_jobs[str(job["jobId"])] = get_build_status(int(job["jobId"]))
     return {
-        "images": build_jobs
+        "images": all_jobs
     }

--- a/vmms/ecrBuilder.py
+++ b/vmms/ecrBuilder.py
@@ -117,7 +117,7 @@ Pin-Priority: -1
 
             # Build the image locally
             print("Building the docker image %s" % image_name)
-            logs = docker_client.api.build(path=tmpdir, tag=full_image_name)
+            logs = docker_client.api.build(path=tmpdir, tag=full_image_name, decode=True)
             for chunk in logs:
                 if "stream" in chunk:
                     print(chunk["stream"], end="")
@@ -151,3 +151,8 @@ Pin-Priority: -1
 
 def get_build_status(job_id):
     return build_jobs.get(str(job_id), {"statusId": 255, "statusMsg": "Job not found"})
+
+def get_all_build_status():
+    return {
+        "images": build_jobs
+    }

--- a/vmms/ecrBuilder.py
+++ b/vmms/ecrBuilder.py
@@ -180,12 +180,6 @@ Pin-Priority: -1
             if 'full_image_name' in locals():
                 docker_client.images.remove(image=full_image_name, force=True)
             
-            # Remove the base template image (if it was pulled)
-            if base_uri is not None:
-                docker_client.images.remove(image=base_uri, force=True)
-            if base_tag is not None:
-                docker_client.images.remove(image=base_tag, force=True)
-            
             #  Prune intermediate `<none>:<none>` dangling layers
             prune_result = docker_client.images.prune(filters={'dangling': True})
             reclaimed = prune_result.get('SpaceReclaimed', 0) / (1024 * 1024) # Convert bytes to MB

--- a/vmms/ecrBuilder.py
+++ b/vmms/ecrBuilder.py
@@ -1,0 +1,80 @@
+import threading
+import tempfile
+import random
+import os
+import docker
+import boto3
+import base64
+
+# In-memory dictionary to track build status
+build_jobs = {}
+
+def start_ecr_build(course_id, image_name, tag, dockerfile_content):
+    # Generate a numeric ID to match the JOBID regex in server.py
+    job_id = str(random.randint(10000, 999999))
+    
+    build_jobs[job_id] = {
+        "statusMsg": "Building image in ECR",
+        "statusId": 1,
+        "jobId": int(job_id)
+    }
+
+    # Spin up background thread to avoid blocking the API
+    thread = threading.Thread(
+        target=_build_and_push_task,
+        args=(job_id, course_id, image_name, tag, dockerfile_content)
+    )
+    thread.daemon = True
+    thread.start()
+
+    return int(job_id)
+
+def _build_and_push_task(job_id, course_id, image_name, tag, dockerfile_content):
+    try:
+        # Authenticate with AWS ECR
+        ecr_client = boto3.client('ecr', region_name='us-east-2')
+        
+        try:
+            ecr_client.describe_repositories(repositoryNames=[image_name])
+        except ecr_client.exceptions.RepositoryNotFoundException:
+            ecr_client.create_repository(repositoryName=image_name)
+
+        auth_response = ecr_client.get_authorization_token()
+        auth_data = auth_response['authorizationData'][0]
+        auth_token = base64.b64decode(auth_data['authorizationToken']).decode('utf-8')
+        username, password = auth_token.split(':')
+        registry = auth_data['proxyEndpoint'].replace('https://', '')
+
+        # Authenticate local Docker daemon with ECR
+        docker_client = docker.from_env()
+        docker_client.login(username=username, password=password, registry=registry)
+
+        # Write Dockerfile to temp directory
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dockerfile_path = os.path.join(tmpdir, 'Dockerfile')
+            with open(dockerfile_path, 'w') as f:
+                f.write(dockerfile_content)
+
+            full_image_name = f"{registry}/{image_name}:{tag}"
+
+            # Build the image locally
+            docker_client.images.build(path=tmpdir, tag=full_image_name)
+
+            # Push to ECR
+            push_logs = docker_client.images.push(full_image_name, stream=True, decode=True)
+            for log in push_logs:
+                if 'error' in log:
+                    raise Exception(log['error'])
+
+        # On Success
+        build_jobs[job_id]["statusId"] = 0
+        build_jobs[job_id]["statusMsg"] = "Image built successfully"
+        build_jobs[job_id]["ecr_image_uri"] = full_image_name
+
+    except Exception as e:
+        # On Failure
+        build_jobs[job_id]["statusId"] = -1
+        build_jobs[job_id]["statusMsg"] = f"Build failed: {str(e)}"
+
+def get_build_status(job_id):
+    return build_jobs.get(str(job_id), {"statusId": -1, "statusMsg": "Job not found"})

--- a/vmms/ecrBuilder.py
+++ b/vmms/ecrBuilder.py
@@ -132,6 +132,12 @@ Pin-Priority: -1
                 if "error" in chunk:
                     print("BUILD ERROR:", chunk["error"])
                     append_build_log(job_id, chunk["error"])
+                    raise Exception(chunk["error"])
+                if "message" in chunk:
+                    print(chunk["message"], end="")
+                    append_build_log(job_id, chunk["message"])
+                    if "dockerfile parse error" in chunk["message"].lower():
+                        raise Exception(chunk["message"])
 
             print("Pushing docker image %s to ECR" % image_name)
             # Push to ECR

--- a/vmms/ecrBuilder.py
+++ b/vmms/ecrBuilder.py
@@ -6,11 +6,13 @@ import docker
 import boto3
 import base64
 import json
+import time
+from config import Config
 
 # In-memory dictionary to track build status
 build_jobs = {}
 
-def start_ecr_build(course_id, image_name, tag, dockerfile_content):
+def start_ecr_build(course_id, image_name, dockerfile_content):
     # Generate a numeric ID to match the JOBID regex in server.py
     #TODO: fix job_id collision, add locks
     job_id = str(random.randint(10000, 999999))
@@ -25,24 +27,26 @@ def start_ecr_build(course_id, image_name, tag, dockerfile_content):
     # Spin up background thread to avoid blocking the API
     thread = threading.Thread(
         target=_build_and_push_task,
-        args=(job_id, course_id, image_name, tag, dockerfile_content)
+        args=(job_id, course_id, image_name, dockerfile_content)
     )
     thread.daemon = True
     thread.start()
 
     return int(job_id)
 
-def _build_and_push_task(job_id, course_id, image_name, tag, dockerfile_content):
+def _build_and_push_task(job_id, course_id, image_name, dockerfile_content):
+    version_tag = f"{image_name}-{int(time.time())}"
+    stable_tag = image_name
     try:
         # Authenticate with AWS ECR
-        ecr_client = boto3.client('ecr', region_name='us-east-2')
+        ecr_client = boto3.client('ecr', region_name=Config.EC2_REGION)
         
         print("Connecting to ECR repository")
         try:
-            ecr_client.describe_repositories(repositoryNames=[image_name])
+            ecr_client.describe_repositories(repositoryNames=[course_id])
         except ecr_client.exceptions.RepositoryNotFoundException:
             print("Creating ECR repository")
-            ecr_client.create_repository(repositoryName=image_name)
+            ecr_client.create_repository(repositoryName=course_id)
             
             # Apply Lifecycle Policy to automatically expire old images
             policy_text = json.dumps({
@@ -64,7 +68,7 @@ def _build_and_push_task(job_id, course_id, image_name, tag, dockerfile_content)
             })
             
             ecr_client.put_lifecycle_policy(
-                repositoryName=image_name,
+                repositoryName=course_id,
                 lifecyclePolicyText=policy_text
             )
 
@@ -86,7 +90,16 @@ def _build_and_push_task(job_id, course_id, image_name, tag, dockerfile_content)
             with open(dockerfile_path, 'w') as f:
                 f.write(dockerfile_content)
 
-            full_image_name = f"{registry}/{image_name}:{tag}"
+            apt_preferences_content = """Package: fakeroot
+Pin: release *
+Pin-Priority: -1
+"""
+
+            apt_preferences_path = os.path.join(tmpdir, 'apt-preferences')
+            with open(apt_preferences_path, 'w') as f:
+                f.write(apt_preferences_content)
+
+            full_image_name = f"{registry}/{course_id}:{version_tag}"
 
             # Build the image locally
             docker_client.images.build(path=tmpdir, tag=full_image_name)
@@ -97,6 +110,9 @@ def _build_and_push_task(job_id, course_id, image_name, tag, dockerfile_content)
             for log in push_logs:
                 if 'error' in log:
                     raise Exception(log['error'])
+            # Tag it with the stable image name
+            docker_client.images.get(full_image_name) \
+                .tag(f"{registry}/{course_id}:{stable_tag}")
 
         # On Success
         build_jobs[job_id]["statusId"] = 0
@@ -104,6 +120,7 @@ def _build_and_push_task(job_id, course_id, image_name, tag, dockerfile_content)
         build_jobs[job_id]["ecrImageUri"] = full_image_name
 
     except Exception as e:
+        print(("Build failed: %s" % e))
         # On Failure
         build_jobs[job_id]["statusId"] = -1
         build_jobs[job_id]["statusMsg"] = f"Build failed: {str(e)}"

--- a/worker.py
+++ b/worker.py
@@ -342,6 +342,7 @@ class Worker(threading.Thread):
                     self.job.setKeepForDebugging(True)
                 elif ret["runjob"] == -1:
                     Config.runjob_timeouts += 1
+                    msg = "RunJob: Status -1"
                     # TODO: difference between 2 and -1?
                 else:  # This should never happen
                     msg = "RunJob: Unknown autodriver error (status=%d)" % (

--- a/worker.py
+++ b/worker.py
@@ -63,7 +63,7 @@ class Worker(threading.Thread):
         """
         # job-owned instance, simply destroy after job is completed
         self.cleanupStatus = True
-        if Config.VMMS_NAME == "ec2SSH":
+        if Config.VMMS_NAME == "ec2SSH" or Config.VMMS_NAME == "ec2Docker":
             self.vmms.safeDestroyVM(self.job.vm)
             # EC2 doesn't use the preallocator
         else:


### PR DESCRIPTION
Changes proposed in this PR:
- Added a `finally` block to the `_build_and_push_task` thread in `ecrBuilder.py` to guarantee local Docker cleanup executes regardless of whether the build succeeds or fails.
- Implemented forceful deletion (`force=True`) of the final compiled ECR image and any pulled base templates from the local EC2 instance to prevent long-term storage bloat.
- Added an automatic garbage collection step using `docker_client.images.prune(filters={'dangling': True})` to instantly remove orphaned intermediate cache layers, actively reclaiming disk space after every build run.