### PR TITLE
Added default vmms to ec2Docker

### DIFF
--- a/config.template.py
+++ b/config.template.py
@@ -41,7 +41,7 @@ class Config(object):
     # VMMS to use. Must be set to a VMMS implemented in vmms/ before
     # starting Tango.  Options are: "localDocker", "distDocker",
     # "tashiSSH", "ec2SSH", "ec2Docker"
-    VMMS_NAME = "localDocker"
+    VMMS_NAME = "ec2Docker"
 
     # Update this to the 'volumes' directory of your Tango installation if
     # Docker is being used as the VMMs.


### PR DESCRIPTION
## Description

In the past, deployment for Tango on EC2 defaulted to localDocker so users would need to SSH to the ec2 container to manually change it. 

This PR changes the default to EC2Docker for ec2.
